### PR TITLE
add mdn admin node for easy EFS access

### DIFF
--- a/apps/mdn/mdn-aws/k8s/Makefile
+++ b/apps/mdn/mdn-aws/k8s/Makefile
@@ -158,6 +158,7 @@ export BACKUP_SECRET_KEY ?= bar
 export BACKUP_ACCESS_KEY_BASE64 ?= $(shell echo -n "${BACKUP_ACCESS_KEY}" | base64)
 export BACKUP_SECRET_KEY_BASE64 ?= $(shell echo -n "${BACKUP_SECRET_KEY}" | base64)
 
+export ADMIN_NODE_NAME ?= mdn-admin
 
 aws-create-mysql-vol:
 	aws ec2 create-volume \
@@ -280,7 +281,14 @@ k8s-sync-from-s3-cron:
 k8s-delete-sync-from-s3-cron:
 	kubectl delete -n ${K8S_NAMESPACE} --ignore-not-found cronjob ${SYNC_FROM_S3_SERVICE_NAME}
 
-# SYNC_FROM_S3_SCHEDULE
+k8s-admin-node:
+	j2 mdn-admin-node.yaml.j2 | kubectl apply -n ${K8S_NAMESPACE} -f -
+	#j2 mdn-admin-node.yaml.j2
+
+k8s-delete-admin-node:
+	kubectl delete -n ${K8S_NAMESPACE} --ignore-not-found deployment ${ADMIN_NODE_NAME}
+
+
 ### end administrative tasks
 ###############################
 

--- a/apps/mdn/mdn-aws/k8s/mdn-admin-node.yaml.j2
+++ b/apps/mdn/mdn-aws/k8s/mdn-admin-node.yaml.j2
@@ -1,0 +1,23 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: {{ ADMIN_NODE_NAME }}
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: {{ ADMIN_NODE_NAME }}
+    spec:
+      containers:
+        - name: {{ ADMIN_NODE_NAME }}
+          image: debian
+          command: [ "/bin/bash", "-c", "--" ]
+          args: [ "while true; do sleep 30; done;" ]
+          volumeMounts:
+            - mountPath: {{ BACKUP_MOUNT_DIR }}
+              name: {{ SHARED_PVC_NAME }}
+      volumes:
+        - name: {{ SHARED_PVC_NAME }}
+          persistentVolumeClaim:
+            claimName: {{ SHARED_PVC_NAME }}


### PR DESCRIPTION
This make target creates a debian container that runs forever (until you delete it). This is great for interacting with EFS (and maybe the awscli if needed).

To connect to the running pod, first find the full name of the `mdn-admin` pod and then exec into it like this:

```
kubectl -n mdn-dev exec -it mdn-admin-3097159426-mks6l bash
```