### PR TITLE
add ability to handle attachments

### DIFF
--- a/apps/mdn/mdn-aws/k8s/Makefile
+++ b/apps/mdn/mdn-aws/k8s/Makefile
@@ -114,15 +114,18 @@ export KUMASCRIPT_MEMCHACHED_URL ?= ${MEMCACHED_URL}
 export KUMA_IMAGE ?= quay.io/mozmar/kuma
 export KUMA_IMAGE_TAG ?= 2fcf608
 export KUMA_IMAGE_PULL_POLICY ?= IfNotPresent
+export KUMA_MEDIA_ROOT ?= /mdn/www/attachments
 # "KUMA_MOUNT_PATH" sets the mount path for the claim of the shared volume.
-export KUMA_MOUNT_PATH ?= /www
+export KUMA_MOUNT_PATH ?= /mdn
 export KUMA_DEBUG ?= False
 export KUMA_DEBUG_TOOLBAR ?= False
 export KUMA_PROTOCOL ?= "https://"
 ifeq (${TARGET_ENVIRONMENT},dev)
 export KUMA_DOMAIN=$(shell kubectl get --ignore-not-found -n ${K8S_NAMESPACE} svc ${WEB_SERVICE_NAME} -o jsonpath={.status.loadBalancer.ingress[0].hostname})
+export KUMA_ATTACHMENT_HOST=${KUMA_DOMAIN}
 else
 export KUMA_DOMAIN ?= developer.mozilla.org
+export KUMA_ATTACHMENT_HOST ?= mdn.mozillademos.org
 endif
 export KUMA_ACCOUNT_DEFAULT_HTTP_PROTOCOL ?= "https"
 export KUMA_ALLOWED_HOSTS ?= *

--- a/apps/mdn/mdn-aws/k8s/Makefile
+++ b/apps/mdn/mdn-aws/k8s/Makefile
@@ -112,7 +112,7 @@ export KUMASCRIPT_DOCUMENT_URL_TEMPLATE ?= http://${API_NAME}/en-US/docs/{path}?
 export KUMASCRIPT_MEMCHACHED_URL ?= ${MEMCACHED_URL}
 
 export KUMA_IMAGE ?= quay.io/mozmar/kuma
-export KUMA_IMAGE_TAG ?= 2fcf608
+export KUMA_IMAGE_TAG ?= f44ba6e
 export KUMA_IMAGE_PULL_POLICY ?= IfNotPresent
 export KUMA_MEDIA_ROOT ?= /mdn/www/attachments
 # "KUMA_MOUNT_PATH" sets the mount path for the claim of the shared volume.
@@ -120,13 +120,8 @@ export KUMA_MOUNT_PATH ?= /mdn
 export KUMA_DEBUG ?= False
 export KUMA_DEBUG_TOOLBAR ?= False
 export KUMA_PROTOCOL ?= "https://"
-ifeq (${TARGET_ENVIRONMENT},dev)
-export KUMA_DOMAIN=$(shell kubectl get --ignore-not-found -n ${K8S_NAMESPACE} svc ${WEB_SERVICE_NAME} -o jsonpath={.status.loadBalancer.ingress[0].hostname})
-export KUMA_ATTACHMENT_HOST=${KUMA_DOMAIN}
-else
-export KUMA_DOMAIN ?= developer.mozilla.org
-export KUMA_ATTACHMENT_HOST ?= mdn.mozillademos.org
-endif
+export KUMA_DOMAIN ?= mdn-dev.moz.works
+export KUMA_ATTACHMENT_HOST ?= mdn-dev.moz.works
 export KUMA_ACCOUNT_DEFAULT_HTTP_PROTOCOL ?= "https"
 export KUMA_ALLOWED_HOSTS ?= *
 export KUMA_SESSION_COOKIE_SECURE ?= True

--- a/apps/mdn/mdn-aws/k8s/kuma.base.deploy.yaml.j2
+++ b/apps/mdn/mdn-aws/k8s/kuma.base.deploy.yaml.j2
@@ -18,8 +18,8 @@ spec:
           image: {{ KUMA_IMAGE }}:{{ KUMA_IMAGE_TAG }}
           imagePullPolicy: {{ KUMA_IMAGE_PULL_POLICY }}
           volumeMounts:
-            - mountPath: {{ KUMA_MOUNT_PATH }}
-              name: kuma-fs
+            - name: kuma-fs
+              mountPath: {{ KUMA_MOUNT_PATH }}
           resources:
             requests:
               cpu: {{ KUMA_CPU_REQUEST }}
@@ -33,6 +33,8 @@ spec:
               value: {{ KUMA_ACCOUNT_DEFAULT_HTTP_PROTOCOL }}
             - name: ALLOWED_HOSTS
               value: "{{ KUMA_ALLOWED_HOSTS }}"
+            - name: ATTACHMENT_HOST
+              value: {{ KUMA_ATTACHMENT_HOST }}
             - name: BROKER_URL
               value: {{ KUMA_CELERY_BROKER_URL }}
             - name: CELERY_ALWAYS_EAGER
@@ -51,6 +53,8 @@ spec:
               value: {{ ELASTICSEARCH_URL }}
             - name: KUMASCRIPT_URL_TEMPLATE
               value: {{ KUMA_URL_TEMPLATE_FOR_KUMASCRIPT }}
+            - name: MEDIA_ROOT
+              value: {{ KUMA_MEDIA_ROOT }}
             - name: MEMCACHE_SERVERS
               value: {{ MEMCACHED_URL }}
             - name: PROD_DETAILS_DIR

--- a/apps/mdn/mdn-aws/k8s/regions/portland/dev.sh
+++ b/apps/mdn/mdn-aws/k8s/regions/portland/dev.sh
@@ -116,14 +116,16 @@ export KUMASCRIPT_DOCUMENT_URL_TEMPLATE=http://${API_NAME}/en-US/docs/{path}?raw
 export KUMASCRIPT_MEMCHACHED_URL=${MEMCACHED_URL}
 
 export KUMA_IMAGE=quay.io/mozmar/kuma
-export KUMA_IMAGE_TAG=5dbf2ca
+export KUMA_IMAGE_TAG=f44ba6e
 export KUMA_IMAGE_PULL_POLICY=IfNotPresent
 export KUMA_MEDIA_ROOT=/mdn/www
 # "KUMA_MOUNT_PATH" sets the mount path for the claim of the shared volume.
 export KUMA_MOUNT_PATH=/mdn
 export KUMA_DEBUG="True"
 export KUMA_DEBUG_TOOLBAR="False"
-export KUMA_PROTOCOL="https://"
+export KUMA_PROTOCOL="http://"
+export KUMA_DOMAIN=mdn-dev.moz.works
+export KUMA_ATTACHMENT_HOST=mdn-dev.moz.works
 export KUMA_ACCOUNT_DEFAULT_HTTP_PROTOCOL="http"
 export KUMA_ALLOWED_HOSTS="*"
 export KUMA_SESSION_COOKIE_SECURE="False"

--- a/apps/mdn/mdn-aws/k8s/regions/portland/dev.sh
+++ b/apps/mdn/mdn-aws/k8s/regions/portland/dev.sh
@@ -116,14 +116,15 @@ export KUMASCRIPT_DOCUMENT_URL_TEMPLATE=http://${API_NAME}/en-US/docs/{path}?raw
 export KUMASCRIPT_MEMCHACHED_URL=${MEMCACHED_URL}
 
 export KUMA_IMAGE=quay.io/mozmar/kuma
-export KUMA_IMAGE_TAG=2fcf608
+export KUMA_IMAGE_TAG=5dbf2ca
 export KUMA_IMAGE_PULL_POLICY=IfNotPresent
+export KUMA_MEDIA_ROOT=/mdn/www
 # "KUMA_MOUNT_PATH" sets the mount path for the claim of the shared volume.
-export KUMA_MOUNT_PATH=/www
+export KUMA_MOUNT_PATH=/mdn
 export KUMA_DEBUG="True"
 export KUMA_DEBUG_TOOLBAR="False"
 export KUMA_PROTOCOL="https://"
-export KUMA_ACCOUNT_DEFAULT_HTTP_PROTOCOL="https"
+export KUMA_ACCOUNT_DEFAULT_HTTP_PROTOCOL="http"
 export KUMA_ALLOWED_HOSTS="*"
 export KUMA_SESSION_COOKIE_SECURE="False"
 export KUMA_WEB_CONCURRENCY="2"

--- a/apps/mdn/mdn-aws/k8s/regions/portland/prod.sh
+++ b/apps/mdn/mdn-aws/k8s/regions/portland/prod.sh
@@ -116,14 +116,16 @@ export KUMASCRIPT_DOCUMENT_URL_TEMPLATE=http://${API_NAME}/en-US/docs/{path}?raw
 export KUMASCRIPT_MEMCHACHED_URL=${MEMCACHED_URL}
 
 export KUMA_IMAGE=quay.io/mozmar/kuma
-export KUMA_IMAGE_TAG=2fcf608
+export KUMA_IMAGE_TAG=5dbf2ca
 export KUMA_IMAGE_PULL_POLICY=IfNotPresent
+export KUMA_MEDIA_ROOT=/mdn/www/attachments
 # "KUMA_MOUNT_PATH" sets the mount path for the claim of the shared volume.
-export KUMA_MOUNT_PATH=/www
+export KUMA_MOUNT_PATH=/mdn
 export KUMA_DEBUG="False"
 export KUMA_DEBUG_TOOLBAR="False"
 export KUMA_PROTOCOL="https://"
 export KUMA_DOMAIN=developer.mozilla.org
+export KUMA_ATTACHMENT_HOST=mdn.mozillademos.org
 export KUMA_ACCOUNT_DEFAULT_HTTP_PROTOCOL="https"
 export KUMA_ALLOWED_HOSTS="developer.mozilla.org, developer.cdn.mozilla.net, mdn.mozillademos.org"
 export KUMA_SESSION_COOKIE_SECURE="True"

--- a/apps/mdn/mdn-aws/k8s/regions/portland/prod.sh
+++ b/apps/mdn/mdn-aws/k8s/regions/portland/prod.sh
@@ -116,7 +116,7 @@ export KUMASCRIPT_DOCUMENT_URL_TEMPLATE=http://${API_NAME}/en-US/docs/{path}?raw
 export KUMASCRIPT_MEMCHACHED_URL=${MEMCACHED_URL}
 
 export KUMA_IMAGE=quay.io/mozmar/kuma
-export KUMA_IMAGE_TAG=5dbf2ca
+export KUMA_IMAGE_TAG=f44ba6e
 export KUMA_IMAGE_PULL_POLICY=IfNotPresent
 export KUMA_MEDIA_ROOT=/mdn/www/attachments
 # "KUMA_MOUNT_PATH" sets the mount path for the claim of the shared volume.

--- a/apps/mdn/mdn-aws/k8s/regions/portland/stage.sh
+++ b/apps/mdn/mdn-aws/k8s/regions/portland/stage.sh
@@ -116,7 +116,7 @@ export KUMASCRIPT_DOCUMENT_URL_TEMPLATE=http://${API_NAME}/en-US/docs/{path}?raw
 export KUMASCRIPT_MEMCHACHED_URL=${MEMCACHED_URL}
 
 export KUMA_IMAGE=quay.io/mozmar/kuma
-export KUMA_IMAGE_TAG=5dbf2ca
+export KUMA_IMAGE_TAG=f44ba6e
 export KUMA_IMAGE_PULL_POLICY=IfNotPresent
 export KUMA_MEDIA_ROOT=/mdn/www/attachments
 # "KUMA_MOUNT_PATH" sets the mount path for the claim of the shared volume.

--- a/apps/mdn/mdn-aws/k8s/regions/portland/stage.sh
+++ b/apps/mdn/mdn-aws/k8s/regions/portland/stage.sh
@@ -116,14 +116,16 @@ export KUMASCRIPT_DOCUMENT_URL_TEMPLATE=http://${API_NAME}/en-US/docs/{path}?raw
 export KUMASCRIPT_MEMCHACHED_URL=${MEMCACHED_URL}
 
 export KUMA_IMAGE=quay.io/mozmar/kuma
-export KUMA_IMAGE_TAG=2fcf608
+export KUMA_IMAGE_TAG=5dbf2ca
 export KUMA_IMAGE_PULL_POLICY=IfNotPresent
+export KUMA_MEDIA_ROOT=/mdn/www/attachments
 # "KUMA_MOUNT_PATH" sets the mount path for the claim of the shared volume.
-export KUMA_MOUNT_PATH=/www
+export KUMA_MOUNT_PATH=/mdn
 export KUMA_DEBUG="False"
 export KUMA_DEBUG_TOOLBAR="False"
 export KUMA_PROTOCOL="https://"
 export KUMA_DOMAIN=developer.allizom.org
+export KUMA_ATTACHMENT_HOST=developer-samples.allizom.org
 export KUMA_ACCOUNT_DEFAULT_HTTP_PROTOCOL="https"
 export KUMA_ALLOWED_HOSTS="developer.allizom.org, developer-local, developer-samples.allizom.org"
 export KUMA_SESSION_COOKIE_SECURE="True"


### PR DESCRIPTION
This is not ready to merge. It depends on https://github.com/mozilla/kuma/pull/4363 and then `KUMA_IMAGE` must be updated to that latest tag hash in quay.io.