### PR TITLE
add SSL/TLS to MDN web service

### DIFF
--- a/apps/mdn/mdn-aws/k8s/Makefile
+++ b/apps/mdn/mdn-aws/k8s/Makefile
@@ -38,9 +38,10 @@ export MYSQL_DATABASE ?= developer_mozilla_org
 
 export WEB_SERVICE_NAME ?= web
 export WEB_SERVICE_TYPE ?= LoadBalancer
-export WEB_SERVICE_PORT ?= 80
+export WEB_SERVICE_PORT ?= 443
 export WEB_SERVICE_TARGET_PORT ?= 8000
 export WEB_SERVICE_PROTOCOL ?= TCP
+export WEB_SERVICE_CERT_ARN ?= arn:aws:acm:us-west-2:236517346949:certificate/7cc49528-32a2-4433-8b38-506325aae062
 
 export API_SERVICE_NAME ?= api
 export API_SERVICE_TYPE ?= ClusterIP
@@ -221,7 +222,8 @@ k8s-web-svc:
 		SERVICE_PORT=${WEB_SERVICE_PORT} \
 		SERVICE_TARGET_PORT=${WEB_SERVICE_TARGET_PORT} \
 		SERVICE_PROTOCOL=${WEB_SERVICE_PROTOCOL} \
-		j2 svc.yaml.j2 | kubectl apply -n ${K8S_NAMESPACE} -f -
+		SERVICE_CERT_ARN=${WEB_SERVICE_CERT_ARN} \
+		j2 cert.svc.yaml.j2 | kubectl apply -n ${K8S_NAMESPACE} -f -
 
 k8s-delete-web-svc:
 	kubectl delete -n ${K8S_NAMESPACE} --ignore-not-found \

--- a/apps/mdn/mdn-aws/k8s/cert.svc.yaml.j2
+++ b/apps/mdn/mdn-aws/k8s/cert.svc.yaml.j2
@@ -1,0 +1,15 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: {{ SERVICE_NAME }}
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-backend-protocol: http
+    service.beta.kubernetes.io/aws-load-balancer-ssl-cert: {{ SERVICE_CERT_ARN }}
+spec:
+  type: {{ SERVICE_TYPE }}
+  selector:
+    app: {{ SERVICE_NAME }}
+  ports:
+    - port: {{ SERVICE_PORT }}
+      targetPort: {{ SERVICE_TARGET_PORT }}
+      protocol: {{ SERVICE_PROTOCOL }}

--- a/apps/mdn/mdn-aws/k8s/regions/portland/dev.sh
+++ b/apps/mdn/mdn-aws/k8s/regions/portland/dev.sh
@@ -41,9 +41,10 @@ export MYSQL_DATABASE=developer_mozilla_org
 
 export WEB_SERVICE_NAME=web
 export WEB_SERVICE_TYPE=LoadBalancer
-export WEB_SERVICE_PORT=80
+export WEB_SERVICE_PORT=443
 export WEB_SERVICE_TARGET_PORT=8000
 export WEB_SERVICE_PROTOCOL=TCP
+export WEB_SERVICE_CERT_ARN=arn:aws:acm:us-west-2:236517346949:certificate/7cc49528-32a2-4433-8b38-506325aae062
 
 export API_SERVICE_NAME=api
 export API_SERVICE_TYPE=ClusterIP
@@ -123,10 +124,10 @@ export KUMA_MEDIA_ROOT=/mdn/www
 export KUMA_MOUNT_PATH=/mdn
 export KUMA_DEBUG="True"
 export KUMA_DEBUG_TOOLBAR="False"
-export KUMA_PROTOCOL="http://"
+export KUMA_PROTOCOL="https://"
 export KUMA_DOMAIN=mdn-dev.moz.works
 export KUMA_ATTACHMENT_HOST=mdn-dev.moz.works
-export KUMA_ACCOUNT_DEFAULT_HTTP_PROTOCOL="http"
+export KUMA_ACCOUNT_DEFAULT_HTTP_PROTOCOL="https"
 export KUMA_ALLOWED_HOSTS="*"
 export KUMA_SESSION_COOKIE_SECURE="False"
 export KUMA_WEB_CONCURRENCY="2"

--- a/apps/mdn/mdn-aws/k8s/regions/portland/prod.sh
+++ b/apps/mdn/mdn-aws/k8s/regions/portland/prod.sh
@@ -41,9 +41,10 @@ export MYSQL_DATABASE=developer_mozilla_org
 
 export WEB_SERVICE_NAME=web
 export WEB_SERVICE_TYPE=LoadBalancer
-export WEB_SERVICE_PORT=80
+export WEB_SERVICE_PORT=443
 export WEB_SERVICE_TARGET_PORT=8000
 export WEB_SERVICE_PROTOCOL=TCP
+export WEB_SERVICE_CERT_ARN=arn:aws:acm:us-west-2:236517346949:certificate/acc4b18f-19cf-4977-a8ba-642d8afc831d
 
 export API_SERVICE_NAME=api
 export API_SERVICE_TYPE=ClusterIP

--- a/apps/mdn/mdn-aws/k8s/regions/portland/stage.sh
+++ b/apps/mdn/mdn-aws/k8s/regions/portland/stage.sh
@@ -41,9 +41,10 @@ export MYSQL_DATABASE=developer_mozilla_org
 
 export WEB_SERVICE_NAME=web
 export WEB_SERVICE_TYPE=LoadBalancer
-export WEB_SERVICE_PORT=80
+export WEB_SERVICE_PORT=443
 export WEB_SERVICE_TARGET_PORT=8000
 export WEB_SERVICE_PROTOCOL=TCP
+export WEB_SERVICE_CERT_ARN=arn:aws:acm:us-west-2:236517346949:certificate/a3ab853f-7c7b-42f2-8317-766e13979be2
 
 export API_SERVICE_NAME=api
 export API_SERVICE_TYPE=ClusterIP
@@ -127,7 +128,7 @@ export KUMA_PROTOCOL="https://"
 export KUMA_DOMAIN=developer.allizom.org
 export KUMA_ATTACHMENT_HOST=developer-samples.allizom.org
 export KUMA_ACCOUNT_DEFAULT_HTTP_PROTOCOL="https"
-export KUMA_ALLOWED_HOSTS="developer.allizom.org, developer-local, developer-samples.allizom.org"
+export KUMA_ALLOWED_HOSTS="developer.allizom.org, developer-local.allizom.org, developer-samples.allizom.org"
 export KUMA_SESSION_COOKIE_SECURE="True"
 export KUMA_WEB_CONCURRENCY="4"
 export KUMA_MAINTENANCE_MODE="False"


### PR DESCRIPTION
@metadave and I got this working in a meeting. Thanks to @metadave for discovering that I had missed changing the `WEB_SERVICE_PORT` from `80` to `443`. Once that was done, we had SSL/TLS for MDN in AWS! 🎉 