### PR TITLE
Cloudfront provisioning for AWS-hosted MDN  (stage/prod)

### DIFF
--- a/apps/mdn/mdn-aws/infra/mdn-cdn/cloudfront/cloudfront.tf
+++ b/apps/mdn/mdn-aws/infra/mdn-cdn/cloudfront/cloudfront.tf
@@ -1,0 +1,74 @@
+variable "distribution_name" {}
+variable "comment" {}
+variable "domain_name" {}
+variable "acm_cert_arn" {}
+
+variable "aliases" {
+  type = "list"
+}
+
+resource "aws_cloudfront_distribution" "mdn-cf-dist" {
+  aliases         = "${var.aliases}"
+  comment         = "${var.comment}"
+  enabled         = true
+  http_version    = "http2"
+  is_ipv6_enabled = false
+  price_class     = "PriceClass_All"
+
+  custom_error_response {
+    error_caching_min_ttl = 10
+    error_code            = 404
+  }
+
+  default_cache_behavior {
+    allowed_methods = ["GET", "HEAD"]
+    cached_methods  = ["GET", "HEAD"]
+    compress        = true
+    default_ttl     = 86400
+
+    # 86400 = 24 hours
+    max_ttl = 31536000
+
+    # 31536000 = 1 year
+    min_ttl                = 0
+    smooth_streaming       = false
+    target_origin_id       = "${var.distribution_name}"
+    viewer_protocol_policy = "redirect-to-https"
+
+    forwarded_values {
+      query_string = false
+
+      cookies {
+        forward = "none"
+      }
+    }
+  }
+
+  origin {
+    domain_name = "${var.domain_name}"
+    origin_id   = "${var.distribution_name}"
+
+    custom_origin_config {
+      http_port                = "80"
+      https_port               = "443"
+      origin_protocol_policy   = "https-only"
+      origin_read_timeout      = 30
+      origin_ssl_protocols     = ["TLSv1", "TLSv1.1", "TLSv1.2"]
+      origin_keepalive_timeout = 5
+    }
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  viewer_certificate {
+    acm_certificate_arn = "${var.acm_cert_arn}"
+    ssl_support_method  = "sni-only"
+
+    # https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution.html#minimum_protocol_version
+    minimum_protocol_version = "TLSv1"
+  }
+}

--- a/apps/mdn/mdn-aws/infra/mdn-cdn/mdn_cdn.tf
+++ b/apps/mdn/mdn-aws/infra/mdn-cdn/mdn_cdn.tf
@@ -10,65 +10,29 @@ terraform {
   }
 }
 
-resource "aws_cloudfront_distribution" "mdn-cf-dist" {
-  aliases = ["cdn.mdn.mozilla.net", "cdn.mdn.moz.works"]
-  comment             = "CDN for AWS-hosted MDN"
-  enabled             = true
-  http_version        = "http2"
-  is_ipv6_enabled     = false
-  price_class         = "PriceClass_All"
 
-  custom_error_response {
-    error_caching_min_ttl = 10
-    error_code            = 404
-  }
+module "mdn-cloudfront-stage" {
+    source = "./cloudfront"
 
-  default_cache_behavior {
-    allowed_methods        = ["GET", "HEAD"]
-    cached_methods         = ["GET", "HEAD"]
-    compress               = true
-    default_ttl            = 86400
-    # 86400 = 24 hours
-    max_ttl                = 31536000
-    # 31536000 = 1 year
-    min_ttl                = 0
-    smooth_streaming       = false
-    target_origin_id = "MDNCDN"
-    viewer_protocol_policy = "redirect-to-https"
-
-    forwarded_values {
-      query_string = false
-      cookies {
-        forward = "none"
-      }
-    }
-  }
-
-  origin {
-    domain_name = "developer.mozilla.org"
-    origin_id   = "MDNCDN"
-    custom_origin_config {
-      http_port = "80"
-      https_port = "443"
-      origin_protocol_policy = "https-only"
-      origin_read_timeout = 30
-      origin_ssl_protocols = ["TLSv1", "TLSv1.1", "TLSv1.2"]
-      origin_keepalive_timeout = 5
-    }
-  }
-
-  restrictions {
-    geo_restriction {
-      restriction_type = "none"
-    }
-  }
-
-  viewer_certificate {
-    acm_certificate_arn = "TODO"
-    ssl_support_method  = "sni-only"
-
-    # https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution.html#minimum_protocol_version
-    minimum_protocol_version = "TLSv1"
-  }
+    acm_cert_arn = ""
+    aliases = ["stage-cdn.mdn.mozilla.net", "stage-cdn.mdn.moz.works"]
+    comment = "Stage CDN for AWS-hosted MDN"
+    distribution_name = "MDNStageCDN"
+    domain_name = "developer.allizom.org"
 }
+
+
+module "mdn-cloudfront-prod" {
+    source = "./cloudfront"
+
+    acm_cert_arn = ""
+    aliases = ["cdn.mdn.mozilla.net", "cdn.mdn.moz.works"]
+    comment = "Prod CDN for AWS-hosted MDN"
+    distribution_name = "MDNProdCDN"
+    domain_name = "developer.mozilla.org"
+}
+
+
+
+
 

--- a/apps/mdn/mdn-aws/infra/mdn-cdn/mdn_cdn.tf
+++ b/apps/mdn/mdn-aws/infra/mdn-cdn/mdn_cdn.tf
@@ -1,0 +1,74 @@
+provider "aws" {
+  region = "${var.region}"
+}
+
+terraform {
+  backend "s3" {
+    bucket = "mdn-cdn-provisioning-tf-state"
+    key    = "tf-state"
+    region = "us-west-2"
+  }
+}
+
+resource "aws_cloudfront_distribution" "mdn-cf-dist" {
+  aliases = ["cdn.mdn.mozilla.org", "cdn.mdn.moz.works"]
+  comment             = "CDN for AWS-hosted MDN"
+  enabled             = true
+  http_version        = "http2"
+  is_ipv6_enabled     = false
+  price_class         = "PriceClass_All"
+
+  custom_error_response {
+    error_caching_min_ttl = 10
+    error_code            = 404
+  }
+
+  default_cache_behavior {
+    allowed_methods        = ["GET", "HEAD"]
+    cached_methods         = ["GET", "HEAD"]
+    compress               = true
+    default_ttl            = 86400
+    # 86400 = 24 hours
+    max_ttl                = 31536000
+    # 31536000 = 1 year
+    min_ttl                = 0
+    smooth_streaming       = false
+    target_origin_id = "MDNCDN"
+    viewer_protocol_policy = "redirect-to-https"
+
+    forwarded_values {
+      query_string = false
+      cookies {
+        forward = "none"
+      }
+    }
+  }
+
+  origin {
+    domain_name = "developer.mozilla.org"
+    origin_id   = "MDNCDN"
+    custom_origin_config {
+      http_port = "80"
+      https_port = "443"
+      origin_protocol_policy = "https-only"
+      origin_read_timeout = 30
+      origin_ssl_protocols = ["TLSv1", "TLSv1.1", "TLSv1.2"]
+      origin_keepalive_timeout = 5
+    }
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  viewer_certificate {
+    acm_certificate_arn = "TODO"
+    ssl_support_method  = "sni-only"
+
+    # https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution.html#minimum_protocol_version
+    minimum_protocol_version = "TLSv1"
+  }
+}
+

--- a/apps/mdn/mdn-aws/infra/mdn-cdn/mdn_cdn.tf
+++ b/apps/mdn/mdn-aws/infra/mdn-cdn/mdn_cdn.tf
@@ -14,7 +14,7 @@ terraform {
 module "mdn-cloudfront-stage" {
     source = "./cloudfront"
 
-    acm_cert_arn = ""
+    acm_cert_arn = "arn:aws:acm:us-east-1:236517346949:certificate/f46733a9-d662-4cb4-b344-b09c8a5cb624"
     aliases = ["stage-cdn.mdn.mozilla.net", "stage-cdn.mdn.moz.works"]
     comment = "Stage CDN for AWS-hosted MDN"
     distribution_name = "MDNStageCDN"
@@ -25,7 +25,7 @@ module "mdn-cloudfront-stage" {
 module "mdn-cloudfront-prod" {
     source = "./cloudfront"
 
-    acm_cert_arn = ""
+    acm_cert_arn = "arn:aws:acm:us-east-1:236517346949:certificate/8f9e3e77-984b-4e1d-92c6-214e79435df3"
     aliases = ["cdn.mdn.mozilla.net", "cdn.mdn.moz.works"]
     comment = "Prod CDN for AWS-hosted MDN"
     distribution_name = "MDNProdCDN"

--- a/apps/mdn/mdn-aws/infra/mdn-cdn/mdn_cdn.tf
+++ b/apps/mdn/mdn-aws/infra/mdn-cdn/mdn_cdn.tf
@@ -11,7 +11,7 @@ terraform {
 }
 
 resource "aws_cloudfront_distribution" "mdn-cf-dist" {
-  aliases = ["cdn.mdn.mozilla.org", "cdn.mdn.moz.works"]
+  aliases = ["cdn.mdn.mozilla.net", "cdn.mdn.moz.works"]
   comment             = "CDN for AWS-hosted MDN"
   enabled             = true
   http_version        = "http2"

--- a/apps/mdn/mdn-aws/infra/mdn-cdn/provision.sh
+++ b/apps/mdn/mdn-aws/infra/mdn-cdn/provision.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+set -e
+set -u
+
+MDN_PROVISIONING_REGION="us-west-2"
+TERRAFORM_ENV="mdn-cdn"
+MDN_PROVISIONING_BUCKET="mdn-cdn-provisioning-tf-state"
+STATE_BUCKET_REGION="us-west-2"
+
+setup_tf_s3_state_store() {
+    echo "Creating Terraform state bucket at s3://${MDN_PROVISIONING_BUCKET} (region ${STATE_BUCKET_REGION})"
+    # The following environment variables are defined in config.sh
+    aws s3 mb s3://${MDN_PROVISIONING_BUCKET} --region ${STATE_BUCKET_REGION}
+}
+
+setup_tf_envs() {
+    # this MUST be run in the dir that this file resides in
+    set +e
+    terraform env new mdn-cdn
+    set -e
+}
+
+check_state_store() {
+    echo "Checking state store"
+    set +e
+    if aws s3 ls s3://${MDN_PROVISIONING_BUCKET} > /dev/null 2>&1; then
+        echo "State store already exists"
+    else
+        echo "Setting up state store"
+        setup_tf_s3_state_store
+        echo "Setting up envs"
+        setup_tf_envs
+    fi
+    set -e
+}
+
+tf_main() {
+    # it's safe to always init the s3 backend
+    terraform init
+
+    setup_tf_envs
+
+    # switch env to virginia, tokyo etc
+    terraform env select ${TERRAFORM_ENV}
+
+    # import local modules
+    terraform get
+
+    PLAN=$(mktemp)
+    terraform plan --out $PLAN
+
+    echo "Please verify plan output above and enter the command"
+    echo "'make it so' followed by enter to continue."
+    echo "Otherwise, Ctrl-C to abort"V
+    read
+
+    # if terraform plan fails, the next command won't run due to
+    # set -e at the top of the script.
+    terraform apply $PLAN
+    rm $PLAN
+}
+
+check_state_store
+tf_main
+
+

--- a/apps/mdn/mdn-aws/infra/mdn-cdn/variables.tf
+++ b/apps/mdn/mdn-aws/infra/mdn-cdn/variables.tf
@@ -1,0 +1,3 @@
+variable "region" {
+  default = "us-west-2"
+}


### PR DESCRIPTION
This PR provisions Cloudfront distributions for (`cdn.mdn.mozilla.net`,`cdn.mdn.moz.works`) and (`stage-cdn.mdn.mozilla.net`,`stage-cdn.mdn.moz.works`), similar to how we've created `interactive-examples.mdn.mozilla.net`. I converted the current Cloudformation template that provisioned `developer.cdn.mozilla.net` to Terraform. It hasn't been run yet as most folks are away at the moment. I'll most likely merge it soon without a certificate ARN and iterate over it later in the week.

- TODO
  - [ ] request certs in us-east-1 for Cloudfront.

@jwhitlock any comment on using `cdn.mdn.mozilla.net` and `cdn.mdn.moz.works`?
