### PR TITLE
tweak bedrock setup/scaling

### DIFF
--- a/apps/bedrock/scale.sh
+++ b/apps/bedrock/scale.sh
@@ -8,22 +8,18 @@ deis limits:set web=250m/1000m --cpu -a bedrock-prod
 deis limits:set clock=300M/600M -a bedrock-prod
 deis limits:set clock=250m/1000m --cpu -a bedrock-prod
 deis autoscale:set web --min=5 --max=20 --cpu-percent=80 -a bedrock-prod
-#deis autoscale:set clock --min=1 --max=1--cpu-percent=80 -a bedrock-prod
-
 
 deis limits:set web=300M/600M -a bedrock-stage
 deis limits:set web=250m/1000m --cpu -a bedrock-stage
 deis limits:set clock=300M/600M -a bedrock-stage
 deis limits:set clock=250m/1000m --cpu -a bedrock-stage
 deis autoscale:set web --min=5 --max=20 --cpu-percent=80 -a bedrock-stage
-#deis autoscale:set clock --min=1 --max=1 --cpu-percent=80 -a bedrock-stage
 
 deis limits:set web=120M/300M -a bedrock-dev
 deis limits:set web=250m/500m --cpu  -a bedrock-dev
 deis limits:set clock=120M/300M -a bedrock-dev
 deis limits:set clock=250m/500m --cpu  -a bedrock-dev
 deis autoscale:set web --min=1 --max=3 --cpu-percent=80 -a bedrock-dev
-#deis autoscale:set clock --min=1 --max=1 --cpu-percent=80 -a bedrock-dev
 
 # scale the clock process
 # this will run DB migrations on it's first run

--- a/apps/bedrock/scale.sh
+++ b/apps/bedrock/scale.sh
@@ -5,17 +5,28 @@ check_meao_env
 
 deis limits:set web=300M/600M -a bedrock-prod
 deis limits:set web=250m/1000m --cpu -a bedrock-prod
+deis limits:set clock=300M/600M -a bedrock-prod
+deis limits:set clock=250m/1000m --cpu -a bedrock-prod
 deis autoscale:set web --min=5 --max=20 --cpu-percent=80 -a bedrock-prod
+#deis autoscale:set clock --min=1 --max=1--cpu-percent=80 -a bedrock-prod
+
 
 deis limits:set web=300M/600M -a bedrock-stage
 deis limits:set web=250m/1000m --cpu -a bedrock-stage
+deis limits:set clock=300M/600M -a bedrock-stage
+deis limits:set clock=250m/1000m --cpu -a bedrock-stage
 deis autoscale:set web --min=5 --max=20 --cpu-percent=80 -a bedrock-stage
+#deis autoscale:set clock --min=1 --max=1 --cpu-percent=80 -a bedrock-stage
 
 deis limits:set web=120M/300M -a bedrock-dev
 deis limits:set web=250m/500m --cpu  -a bedrock-dev
-deis autoscale:set web --min=3 --max=5 --cpu-percent=80 -a bedrock-dev
+deis limits:set clock=120M/300M -a bedrock-dev
+deis limits:set clock=250m/500m --cpu  -a bedrock-dev
+deis autoscale:set web --min=1 --max=3 --cpu-percent=80 -a bedrock-dev
+#deis autoscale:set clock --min=1 --max=1 --cpu-percent=80 -a bedrock-dev
 
 # scale the clock process
 # this will run DB migrations on it's first run
 deis scale clock=1 -a bedrock-prod
 deis scale clock=1 -a bedrock-stage
+deis scale clock=1 -a bedrock-dev

--- a/apps/bedrock/setup.sh
+++ b/apps/bedrock/setup.sh
@@ -4,6 +4,10 @@ source ../bin/common.sh
 check_meao_env
 check_neres_env
 
+if [ -z "${KOPS_NAME}" ]; then
+  echo "Please set the $KOPS_NAME env var, which is typically located in a config.sh"
+  exit 1
+fi
 
 setup_monitors() {
     create_monitor_if_missing \
@@ -28,10 +32,10 @@ deis config:set ALLOWED_HOSTS=\* -a bedrock-stage
 deis config:set ALLOWED_HOSTS=\* -a bedrock-dev
 
 deis domains:add www.allizom.org -a bedrock-stage
-deis config:set DEIS_DOMAIN=frankfurt.moz.works -a bedrock-stage
+deis config:set DEIS_DOMAIN=${KOPS_NAME} -a bedrock-stage
 
 deis domains:add www.mozilla.org -a bedrock-prod
-deis config:set DEIS_DOMAIN=frankfurt.moz.works -a bedrock-prod
+deis config:set DEIS_DOMAIN=${KOPS_NAME} -a bedrock-prod
 
 kubectl -n bedrock-prod apply -f ./k8s/bedrock-prod-nodeport.yaml
 kubectl -n bedrock-stage apply -f ./k8s/bedrock-stage-nodeport.yaml


### PR DESCRIPTION
@jgmize we aren't setting limits for the clock proc in Bedrock, this PR proposes some new values that have *NOT* been applied to any clusters.