### PR TITLE
provision MDN stage resources

### DIFF
--- a/apps/mdn/mdn-aws/infra/multi_region/tf/main.tf
+++ b/apps/mdn/mdn-aws/infra/multi_region/tf/main.tf
@@ -22,13 +22,13 @@ module "efs-dev" {
     nodes_security_group = "${var.nodes_security_group}"
 }
 
-#module "efs-stage" {
-#    source = "efs"
-#    efs_name = "stage"
-#    subnets = "${var.subnets}"
-#    nodes_security_group = "${var.nodes_security_group}"
-#}
-#
+module "efs-stage" {
+    source = "efs"
+    efs_name = "stage"
+    subnets = "${var.subnets}"
+    nodes_security_group = "${var.nodes_security_group}"
+}
+
 #module "efs-prod" {
 #    source = "efs"
 #    efs_name = "prod"
@@ -50,15 +50,15 @@ module "redis-dev" {
     nodes_security_group = "${var.nodes_security_group}"
 }
 
-#module "redis-stage" {
-#    source = "redis"
-#    redis_name = "stage"
-#    redis_node_size = "cache.t2.small"
-#    redis_num_nodes = 3
-#    subnets = "${var.subnets}"
-#    nodes_security_group = "${var.nodes_security_group}"
-#}
-#
+module "redis-stage" {
+    source = "redis"
+    redis_name = "stage"
+    redis_node_size = "cache.t2.small"
+    redis_num_nodes = 3
+    subnets = "${var.subnets}"
+    nodes_security_group = "${var.nodes_security_group}"
+}
+
 #module "redis-prod" {
 #    source = "redis"
 #    redis_name = "prod"
@@ -82,15 +82,15 @@ module "memcached-dev" {
     nodes_security_group = "${var.nodes_security_group}"
 }
 
-#module "memcached-stage" {
-#    source = "memcached"
-#    memcached_name = "stage"
-#    memcached_node_size = "cache.t2.small"
-#    memcached_num_nodes = 3
-#    subnets = "${var.subnets}"
-#    nodes_security_group = "${var.nodes_security_group}"
-#}
-#
+module "memcached-stage" {
+    source = "memcached"
+    memcached_name = "stage"
+    memcached_node_size = "cache.t2.small"
+    memcached_num_nodes = 3
+    subnets = "${var.subnets}"
+    nodes_security_group = "${var.nodes_security_group}"
+}
+
 #module "memcached-prod" {
 #    source = "memcached"
 #    memcached_name = "dev"

--- a/apps/mdn/mdn-aws/infra/multi_region/tf/main.tf
+++ b/apps/mdn/mdn-aws/infra/multi_region/tf/main.tf
@@ -109,7 +109,7 @@ module "mysql-stage" {
     source = "rds"
     # DBName must begin with a letter and contain only alphanumeric characters
     mysql_env     = "stage"
-    mysql_db_name = "mdnstage"
+    mysql_db_name = "developer_allizom_org"
     mysql_username = "mdn"
     mysql_password = "${var.mysql_stage_password}"
     mysql_identifier = "mdnstage"
@@ -122,7 +122,7 @@ module "mysql-stage" {
 #module "mysql-prod" {
 #    source = "rds"
 #    # DBName must begin with a letter and contain only alphanumeric characters
-#    mysql_db_name = "mdnprod"
+#    mysql_db_name = "developer_mozilla_org"
 #    mysql_username = "mdn"
 #    mysql_password = "${var.mysql_prod_password}"
 #    mysql_identifier = "mdnprod"

--- a/apps/mdn/mdn-aws/infra/multi_region/tf/main.tf
+++ b/apps/mdn/mdn-aws/infra/multi_region/tf/main.tf
@@ -108,6 +108,7 @@ module "memcached-dev" {
 module "mysql-stage" {
     source = "rds"
     # DBName must begin with a letter and contain only alphanumeric characters
+    mysql_env     = "stage"
     mysql_db_name = "mdnstage"
     mysql_username = "mdn"
     mysql_password = "${var.mysql_stage_password}"

--- a/apps/mdn/mdn-aws/infra/multi_region/tf/main.tf
+++ b/apps/mdn/mdn-aws/infra/multi_region/tf/main.tf
@@ -105,19 +105,19 @@ module "memcached-dev" {
 # MySQL
 #########################################
 
-#module "mysql-stage" {
-#    source = "rds"
-#    # DBName must begin with a letter and contain only alphanumeric characters
-#    mysql_db_name = "mdnstage"
-#    mysql_username = "mdn"
-#    mysql_password = "${var.mysql_stage_password}"
-#    mysql_identifier = "mdnstage"
-#    # stage instace class is much smaller than prod
-#    mysql_instance_class = "db.t2.medium"
-#    mysql_backup_retention_days = 0
-#    vpc_id = "${var.vpc_id}"
-#}
-#
+module "mysql-stage" {
+    source = "rds"
+    # DBName must begin with a letter and contain only alphanumeric characters
+    mysql_db_name = "mdnstage"
+    mysql_username = "mdn"
+    mysql_password = "${var.mysql_stage_password}"
+    mysql_identifier = "mdnstage"
+    # stage instace class is much smaller than prod
+    mysql_instance_class = "db.t2.medium"
+    mysql_backup_retention_days = 0
+    vpc_id = "${var.vpc_id}"
+}
+
 #module "mysql-prod" {
 #    source = "rds"
 #    # DBName must begin with a letter and contain only alphanumeric characters

--- a/apps/mdn/mdn-aws/infra/multi_region/tf/rds/rds.tf
+++ b/apps/mdn/mdn-aws/infra/multi_region/tf/rds/rds.tf
@@ -7,6 +7,8 @@ variable "mysql_password" {}
 
 variable "mysql_identifier" {}
 
+variable "mysql_env" {}
+
 variable "mysql_storage" {
   default     = "100"
   description = "Storage size in GB"
@@ -106,6 +108,9 @@ resource "aws_db_instance" "mdn_rds" {
   storage_encrypted           = "${var.mysql_storage_encrypted}"
   username                    = "${var.mysql_username}"
   vpc_security_group_ids      = ["${aws_security_group.mdn_rds_sg.id}"]
+  tags {
+    "Stack"                   = "MDN-${var.mysql_env}"
+  }
 }
 
 resource "aws_security_group" "mdn_rds_sg" {

--- a/apps/mdn/mdn-aws/infra/multi_region/tf/rds/rds.tf
+++ b/apps/mdn/mdn-aws/infra/multi_region/tf/rds/rds.tf
@@ -100,7 +100,7 @@ resource "aws_db_instance" "mdn_rds" {
   identifier                  = "${var.mysql_identifier}"
   instance_class              = "${var.mysql_instance_class}"
   maintenance_window          = "${var.mysql_maintenance_window}"
-  multi_az                    = true
+  multi_az                    = false
   name                        = "${var.mysql_db_name}"
   parameter_group_name        = "${aws_db_parameter_group.mdn-params.name}"
   password                    = "${var.mysql_password}"

--- a/apps/mdn/mdn-aws/infra/multi_region/tf/rds/rds.tf
+++ b/apps/mdn/mdn-aws/infra/multi_region/tf/rds/rds.tf
@@ -71,29 +71,41 @@ variable "cidr_blocks" {
   description = "CIDR for sg"
 }
 
+resource "aws_db_parameter_group" "mdn-params" {
+  name        = "${var.mysql_identifier}-params"
+  family      = "mysql5.6"
+  description = "Paramter group for ${var.mysql_identifier}"
+
+  # https://stackoverflow.com/questions/8744813/mysql-error-2006-hy000-at-line-406-mysql-server-has-gone-away#10709964
+  parameter {
+    name      = "max_allowed_packet"
+    value     = "26214400"
+  }
+}
 
 resource "aws_db_instance" "mdn_rds" {
-  depends_on                  = ["aws_security_group.mdn_rds_sg"]
-  identifier                  = "${var.mysql_identifier}"
   allocated_storage           = "${var.mysql_storage}"
-  engine                      = "${var.mysql_engine}"
-  engine_version              = "${lookup(var.mysql_engine_version, var.mysql_engine)}"
-  instance_class              = "${var.mysql_instance_class}"
-  name                        = "${var.mysql_db_name}"
-  username                    = "${var.mysql_username}"
-  password                    = "${var.mysql_password}"
-  vpc_security_group_ids      = ["${aws_security_group.mdn_rds_sg.id}"]
+  allow_major_version_upgrade = "${var.mysql_allow_major_version_upgrade}"
+  auto_minor_version_upgrade  = "${var.mysql_auto_minor_version_upgrade}"
+  backup_retention_period     = "${var.mysql_backup_retention_days}"
+  backup_window               = "${var.mysql_backup_window}"
   # note: this resource already existed at time of provisioning from
   # our k8s install automation
   db_subnet_group_name        = "main_subnet_group"
-  backup_retention_period     = "${var.mysql_backup_retention_days}"
-  multi_az                    = true
-  backup_window               = "${var.mysql_backup_window}"
+  depends_on                  = ["aws_security_group.mdn_rds_sg"]
+  engine                      = "${var.mysql_engine}"
+  engine_version              = "${lookup(var.mysql_engine_version, var.mysql_engine)}"
+  identifier                  = "${var.mysql_identifier}"
+  instance_class              = "${var.mysql_instance_class}"
   maintenance_window          = "${var.mysql_maintenance_window}"
+  multi_az                    = true
+  name                        = "${var.mysql_db_name}"
+  parameter_group_name        = "${aws_db_parameter_group.mdn-params.name}"
+  password                    = "${var.mysql_password}"
   publicly_accessible         = false
   storage_encrypted           = "${var.mysql_storage_encrypted}"
-  auto_minor_version_upgrade  = "${var.mysql_auto_minor_version_upgrade}"
-  allow_major_version_upgrade = "${var.mysql_allow_major_version_upgrade}"
+  username                    = "${var.mysql_username}"
+  vpc_security_group_ids      = ["${aws_security_group.mdn_rds_sg.id}"]
 }
 
 resource "aws_security_group" "mdn_rds_sg" {

--- a/apps/mdn/mdn-aws/infra/multi_region/tf/variables.tf
+++ b/apps/mdn/mdn-aws/infra/multi_region/tf/variables.tf
@@ -6,7 +6,7 @@ variable "nodes_security_group" {}
 
 variable "vpc_id" {}
 
-#variable "mysql_stage_password" {}
+variable "mysql_stage_password" {}
 
 #variable "mysql_prod_password" {}
 


### PR DESCRIPTION
- create a db parameter group per environment (stage/prod) to support any custom params
  - set a value for `max_allowed_packet`, as documented [here](https://mana.mozilla.org/wiki/display/websites/developer.mozilla.org+Cluster#developer.mozilla.orgCluster-Database)
- all parameters for `resource "aws_db_instance" "mdn_rds" { ... }` were sorted, and `parameter_group_name` was added.
- provisioned MDN stage database, redis/memcached clusters, EFS
- EFS is currently empty, I'll setup the directory structure when I get back!