### PR TITLE
fix stage deployments

### DIFF
--- a/apps/mdn/mdn-aws/k8s/Makefile
+++ b/apps/mdn/mdn-aws/k8s/Makefile
@@ -41,6 +41,7 @@ export WEB_CPU_LIMIT ?= 2
 export WEB_CPU_REQUEST ?= 100m
 export WEB_MEMORY_LIMIT ?= 4Gi
 export WEB_MEMORY_REQUEST ?= 256Mi
+export WEB_ALLOWED_HOSTS ?= "*"
 
 export API_NAME ?= api
 export API_REPLICAS ?= 1
@@ -50,6 +51,7 @@ export API_CPU_LIMIT ?= 2
 export API_CPU_REQUEST ?= 100m
 export API_MEMORY_LIMIT ?= 4Gi
 export API_MEMORY_REQUEST ?= 256Mi
+export API_ALLOWED_HOSTS ?= ${API_SERVICE_NAME}
 
 export CELERY_WORKERS_NAME ?= celery-worker
 export CELERY_WORKERS_REPLICAS ?= 1
@@ -84,7 +86,7 @@ export KUMASCRIPT_CPU_LIMIT ?= 2
 export KUMASCRIPT_CPU_REQUEST ?= 100m
 export KUMASCRIPT_MEMORY_LIMIT ?= 4Gi
 export KUMASCRIPT_MEMORY_REQUEST ?= 256Mi
-export KUMASCRIPT_DOCUMENT_URL_TEMPLATE ?= http://${API_NAME}/en-US/docs/{path}?raw=1
+export KUMASCRIPT_DOCUMENT_URL_TEMPLATE ?= http://${API_SERVICE_NAME}/en-US/docs/{path}?raw=1
 
 export KUMA_IMAGE ?= quay.io/mozmar/kuma
 export KUMA_IMAGE_TAG ?= f44ba6e
@@ -98,7 +100,6 @@ export KUMA_PROTOCOL ?= "https://"
 export KUMA_DOMAIN ?= mdn-dev.moz.works
 export KUMA_ATTACHMENT_HOST ?= mdn-dev.moz.works
 export KUMA_ACCOUNT_DEFAULT_HTTP_PROTOCOL ?= "https"
-export KUMA_ALLOWED_HOSTS ?= *
 export KUMA_SESSION_COOKIE_SECURE ?= True
 export KUMA_WEB_CONCURRENCY ?= 4
 export KUMA_MAINTENANCE_MODE ?= False
@@ -263,6 +264,7 @@ k8s-delete-deployments: k8s-delete-web k8s-delete-api \
 k8s-web:
 	env KUMA_NAME=${WEB_NAME} \
 		KUMA_REPLICAS=${WEB_REPLICAS} \
+		KUMA_APP_LABEL=${WEB_SERVICE_NAME} \
 		KUMA_CONTAINER_PORT=${WEB_SERVICE_TARGET_PORT} \
 		KUMA_GUNICORN_WORKERS=${WEB_GUNICORN_WORKERS} \
 		KUMA_GUNICORN_TIMEOUT=${WEB_GUNICORN_TIMEOUT} \
@@ -270,6 +272,7 @@ k8s-web:
 		KUMA_MEMORY_LIMIT=${WEB_MEMORY_LIMIT} \
 		KUMA_CPU_REQUEST=${WEB_CPU_REQUEST} \
 		KUMA_MEMORY_REQUEST=${WEB_MEMORY_REQUEST} \
+		KUMA_ALLOWED_HOSTS=${WEB_ALLOWED_HOSTS} \
 		j2 kuma.deploy.yaml.j2 | kubectl apply -n ${K8S_NAMESPACE} -f -
 
 k8s-delete-web:
@@ -278,6 +281,7 @@ k8s-delete-web:
 k8s-api:
 	env KUMA_NAME=${API_NAME} \
 		KUMA_REPLICAS=${API_REPLICAS} \
+		KUMA_APP_LABEL=${API_SERVICE_NAME} \
 		KUMA_CONTAINER_PORT=${API_SERVICE_TARGET_PORT} \
 		KUMA_GUNICORN_WORKERS=${API_GUNICORN_WORKERS} \
 		KUMA_GUNICORN_TIMEOUT=${API_GUNICORN_TIMEOUT} \
@@ -285,13 +289,15 @@ k8s-api:
 		KUMA_MEMORY_LIMIT=${API_MEMORY_LIMIT} \
 		KUMA_CPU_REQUEST=${API_CPU_REQUEST} \
 		KUMA_MEMORY_REQUEST=${API_MEMORY_REQUEST} \
+		KUMA_ALLOWED_HOSTS=${API_ALLOWED_HOSTS} \
 		j2 kuma.deploy.yaml.j2 | kubectl apply -n ${K8S_NAMESPACE} -f -
 
 k8s-delete-api:
 	kubectl delete -n ${K8S_NAMESPACE} --ignore-not-found deploy ${API_NAME}
 
 k8s-kumascript:
-	j2 kumascript.deploy.yaml.j2 | kubectl apply -n ${K8S_NAMESPACE} -f -
+	env KUMASCRIPT_APP_LABEL=${KUMASCRIPT_SERVICE_NAME} \
+		j2 kumascript.deploy.yaml.j2 | kubectl apply -n ${K8S_NAMESPACE} -f -
 
 k8s-delete-kumascript:
 	kubectl delete -n ${K8S_NAMESPACE} --ignore-not-found \
@@ -304,11 +310,13 @@ k8s-delete-celery: k8s-delete-celery-workers k8s-delete-celery-beat \
 
 k8s-celery-workers:
 	env KUMA_NAME=${CELERY_WORKERS_NAME} \
+		KUMA_APP_LABEL=${CELERY_WORKERS_NAME} \
 		KUMA_REPLICAS=${CELERY_WORKERS_REPLICAS} \
 		KUMA_CPU_LIMIT=${CELERY_WORKERS_CPU_LIMIT} \
 		KUMA_MEMORY_LIMIT=${CELERY_WORKERS_MEMORY_LIMIT} \
 		KUMA_CPU_REQUEST=${CELERY_WORKERS_CPU_REQUEST} \
 		KUMA_MEMORY_REQUEST=${CELERY_WORKERS_MEMORY_REQUEST} \
+		KUMA_ALLOWED_HOSTS="" \
 		j2 celery.workers.deploy.yaml.j2 | kubectl apply -n ${K8S_NAMESPACE} -f -
 
 k8s-delete-celery-workers:
@@ -317,11 +325,13 @@ k8s-delete-celery-workers:
 
 k8s-celery-beat:
 	env KUMA_NAME=${CELERY_BEAT_NAME} \
+		KUMA_APP_LABEL=${CELERY_BEAT_NAME} \
 		KUMA_REPLICAS=${CELERY_BEAT_REPLICAS} \
 		KUMA_CPU_LIMIT=${CELERY_BEAT_CPU_LIMIT} \
 		KUMA_MEMORY_LIMIT=${CELERY_BEAT_MEMORY_LIMIT} \
 		KUMA_CPU_REQUEST=${CELERY_BEAT_CPU_REQUEST} \
 		KUMA_MEMORY_REQUEST=${CELERY_BEAT_MEMORY_REQUEST} \
+		KUMA_ALLOWED_HOSTS="" \
 		j2 celery.beat.deploy.yaml.j2 | kubectl apply -n ${K8S_NAMESPACE} -f -
 
 k8s-delete-celery-beat:
@@ -330,11 +340,13 @@ k8s-delete-celery-beat:
 
 k8s-celery-cam:
 	env KUMA_NAME=${CELERY_CAM_NAME} \
+		KUMA_APP_LABEL=${CELERY_CAM_NAME} \
 		KUMA_REPLICAS=${CELERY_CAM_REPLICAS} \
 		KUMA_CPU_LIMIT=${CELERY_CAM_CPU_LIMIT} \
 		KUMA_MEMORY_LIMIT=${CELERY_CAM_MEMORY_LIMIT} \
 		KUMA_CPU_REQUEST=${CELERY_CAM_CPU_REQUEST} \
 		KUMA_MEMORY_REQUEST=${CELERY_CAM_MEMORY_REQUEST} \
+		KUMA_ALLOWED_HOSTS="" \
 		j2 celery.cam.deploy.yaml.j2 | kubectl apply -n ${K8S_NAMESPACE} -f -
 
 k8s-delete-celery-cam:

--- a/apps/mdn/mdn-aws/k8s/kuma.base.deploy.yaml.j2
+++ b/apps/mdn/mdn-aws/k8s/kuma.base.deploy.yaml.j2
@@ -7,7 +7,7 @@ spec:
   template:
     metadata:
       labels:
-        app: {{ KUMA_NAME }}
+        app: {{ KUMA_APP_LABEL }}
     spec:
       volumes:
         - name: kuma-fs

--- a/apps/mdn/mdn-aws/k8s/kuma.deploy.yaml.j2
+++ b/apps/mdn/mdn-aws/k8s/kuma.deploy.yaml.j2
@@ -14,11 +14,17 @@
             httpGet:
               path: /healthz
               port: {{ KUMA_CONTAINER_PORT }}
+              httpHeaders:
+                - name: Host
+                  value: {{ KUMA_ALLOWED_HOSTS.split(',')[0].strip() }}
             initialDelaySeconds: 20
             periodSeconds: 3
           readinessProbe:
             httpGet:
               path: /readiness
               port: {{ KUMA_CONTAINER_PORT }}
+              httpHeaders:
+                - name: Host
+                  value: {{ KUMA_ALLOWED_HOSTS.split(',')[0].strip() }}
             initialDelaySeconds: 20
             periodSeconds: 3

--- a/apps/mdn/mdn-aws/k8s/kumascript.deploy.yaml.j2
+++ b/apps/mdn/mdn-aws/k8s/kumascript.deploy.yaml.j2
@@ -7,7 +7,7 @@ spec:
   template:
     metadata:
       labels:
-        app: {{ KUMASCRIPT_NAME }}
+        app: {{ KUMASCRIPT_APP_LABEL }}
     spec:
       containers:
         - name: {{ KUMASCRIPT_NAME }}

--- a/apps/mdn/mdn-aws/k8s/regions/portland/dev.sh
+++ b/apps/mdn/mdn-aws/k8s/regions/portland/dev.sh
@@ -48,6 +48,7 @@ export WEB_CPU_LIMIT=2
 export WEB_CPU_REQUEST=100m
 export WEB_MEMORY_LIMIT=4Gi
 export WEB_MEMORY_REQUEST=256Mi
+export WEB_ALLOWED_HOSTS="*"
 
 export API_NAME=api
 export API_REPLICAS=1
@@ -105,7 +106,6 @@ export KUMA_PROTOCOL="https://"
 export KUMA_DOMAIN=mdn-dev.moz.works
 export KUMA_ATTACHMENT_HOST=mdn-dev.moz.works
 export KUMA_ACCOUNT_DEFAULT_HTTP_PROTOCOL="https"
-export KUMA_ALLOWED_HOSTS="*"
 export KUMA_SESSION_COOKIE_SECURE="False"
 export KUMA_WEB_CONCURRENCY="2"
 export KUMA_MAINTENANCE_MODE="False"

--- a/apps/mdn/mdn-aws/k8s/regions/portland/prod.sh
+++ b/apps/mdn/mdn-aws/k8s/regions/portland/prod.sh
@@ -47,6 +47,7 @@ export WEB_CPU_LIMIT=4
 export WEB_CPU_REQUEST=2
 export WEB_MEMORY_LIMIT=16Gi
 export WEB_MEMORY_REQUEST=8Gi
+export WEB_ALLOWED_HOSTS="mdn-prod.moz.works,developer.mozilla.org,developer.cdn.mozilla.net,mdn.mozillademos.org"
 
 export API_NAME=api
 export API_REPLICAS=1
@@ -104,7 +105,6 @@ export KUMA_PROTOCOL="https://"
 export KUMA_DOMAIN=developer.mozilla.org
 export KUMA_ATTACHMENT_HOST=mdn.mozillademos.org
 export KUMA_ACCOUNT_DEFAULT_HTTP_PROTOCOL="https"
-export KUMA_ALLOWED_HOSTS="developer.mozilla.org, developer.cdn.mozilla.net, mdn.mozillademos.org"
 export KUMA_SESSION_COOKIE_SECURE="True"
 export KUMA_WEB_CONCURRENCY="4"
 export KUMA_MAINTENANCE_MODE="False"

--- a/apps/mdn/mdn-aws/k8s/regions/portland/stage.sh
+++ b/apps/mdn/mdn-aws/k8s/regions/portland/stage.sh
@@ -47,6 +47,7 @@ export WEB_CPU_LIMIT=2
 export WEB_CPU_REQUEST=500m
 export WEB_MEMORY_LIMIT=8Gi
 export WEB_MEMORY_REQUEST=1Gi
+export WEB_ALLOWED_HOSTS="mdn-stage.moz.works,developer.allizom.org,developer-local.allizom.org,developer-samples.allizom.org"
 
 export API_NAME=api
 export API_REPLICAS=1
@@ -93,7 +94,7 @@ export KUMASCRIPT_MEMORY_REQUEST=1Gi
 export KUMASCRIPT_DOCUMENT_URL_TEMPLATE=http://${API_NAME}/en-US/docs/{path}?raw=1
 
 export KUMA_IMAGE=quay.io/mozmar/kuma
-export KUMA_IMAGE_TAG=f44ba6e
+export KUMA_IMAGE_TAG=e04e801
 export KUMA_IMAGE_PULL_POLICY=IfNotPresent
 export KUMA_MEDIA_ROOT=/mdn/www
 # "KUMA_MOUNT_PATH" sets the mount path for the claim of the shared volume.
@@ -104,7 +105,6 @@ export KUMA_PROTOCOL="https://"
 export KUMA_DOMAIN=developer.allizom.org
 export KUMA_ATTACHMENT_HOST=developer-samples.allizom.org
 export KUMA_ACCOUNT_DEFAULT_HTTP_PROTOCOL="https"
-export KUMA_ALLOWED_HOSTS="developer.allizom.org, developer-local.allizom.org, developer-samples.allizom.org"
 export KUMA_SESSION_COOKIE_SECURE="True"
 export KUMA_WEB_CONCURRENCY="4"
 export KUMA_MAINTENANCE_MODE="False"


### PR DESCRIPTION
This PR requires https://github.com/mozmeao/mdn-k8s-private/pull/10 for successful deployment. It fixes the following issues with the stage deployment:
* use proper host header in liveness/readiness probes
* use API_SERVICE_NAME as ALLOWED_HOSTS for the api
  deployment
* ensure the deployment "app" label is set properly
  (for example, it should be the WEB_SERVICE_NAME for
   the web deployment)
* use the API_SERVICE_NAME not the API_NAME for the
  KUMASCRIPT_DOCUMENT_URL_TEMPLATE