### PR TITLE
use single env EMAIL_URL specified from email-url secret

### DIFF
--- a/apps/mdn/mdn-aws/k8s/kuma.base.deploy.yaml.j2
+++ b/apps/mdn/mdn-aws/k8s/kuma.base.deploy.yaml.j2
@@ -73,21 +73,11 @@ spec:
               value: {{ KUMA_DOMAIN }}
             - name: EMAIL_BACKEND
               value: {{ KUMA_EMAIL_BACKEND }}
-            - name: EMAIL_HOST
+            - name: EMAIL_URL
               valueFrom:
                 secretKeyRef:
                   name: mdn-secrets
-                  key: email-host
-            - name: EMAIL_HOST_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: mdn-secrets
-                  key: email-host-password
-            - name: EMAIL_HOST_USER
-              valueFrom:
-                secretKeyRef:
-                  name: mdn-secrets
-                  key: email-host-user
+                  key: email-url
             - name: ES_INDEX_PREFIX
               value: {{ KUMA_ES_INDEX_PREFIX }}
             - name: ES_LIVE_INDEX


### PR DESCRIPTION
The email settings were not working, and I discovered that Kuma was already coded (in `kuma/settings/common.py`) to consume the `EMAIL_URL` env override (parsed using the `dj-email-url` Python package) rather than the separate `EMAIL_HOST`, `EMAIL_HOST_USER`, and `EMAIL_HOST_PASSWORD` env overrides This PR depends on https://github.com/mozmeao/mdn-k8s-private/pull/18 which creates the `email-url` secret.