### PR TITLE
add env override for SECURE_HSTS_SECONDS

### DIFF
--- a/apps/mdn/mdn-aws/k8s/Makefile
+++ b/apps/mdn/mdn-aws/k8s/Makefile
@@ -111,6 +111,7 @@ export KUMA_MAINTENANCE_MODE ?= False
 export KUMA_MEDIA_ROOT ?= /mdn/www
 export KUMA_MEDIA_URL ?= /media/
 export KUMA_PROTOCOL ?= "https://"
+export KUMA_SECURE_HSTS_SECONDS ?= 0
 export KUMA_SERVE_LEGACY ?= True
 export KUMA_SESSION_COOKIE_SECURE ?= True
 export KUMA_STATIC_URL ?= /static/

--- a/apps/mdn/mdn-aws/k8s/kuma.base.deploy.yaml.j2
+++ b/apps/mdn/mdn-aws/k8s/kuma.base.deploy.yaml.j2
@@ -104,6 +104,8 @@ spec:
                   key: memcached-url
             - name: PROTOCOL
               value: {{ KUMA_PROTOCOL }}
+            - name: SECURE_HSTS_SECONDS
+              value: "{{ KUMA_SECURE_HSTS_SECONDS }}"
             - name: SENTRY_DSN
               valueFrom:
                 secretKeyRef:

--- a/apps/mdn/mdn-aws/k8s/regions/portland/dev.sh
+++ b/apps/mdn/mdn-aws/k8s/regions/portland/dev.sh
@@ -117,6 +117,7 @@ export KUMA_MAINTENANCE_MODE=False
 export KUMA_MEDIA_ROOT=/mdn/www
 export KUMA_MEDIA_URL=/media/
 export KUMA_PROTOCOL="https://"
+export KUMA_SECURE_HSTS_SECONDS=0
 export KUMA_SERVE_LEGACY=True
 export KUMA_SESSION_COOKIE_SECURE=False
 export KUMA_STATIC_URL=/static/

--- a/apps/mdn/mdn-aws/k8s/regions/portland/prod.sh
+++ b/apps/mdn/mdn-aws/k8s/regions/portland/prod.sh
@@ -116,6 +116,7 @@ export KUMA_MAINTENANCE_MODE=False
 export KUMA_MEDIA_ROOT=/mdn/www
 export KUMA_MEDIA_URL=https://developer.cdn.mozilla.net/media/
 export KUMA_PROTOCOL="https://"
+export KUMA_SECURE_HSTS_SECONDS=63072000
 export KUMA_SERVE_LEGACY=True
 export KUMA_SESSION_COOKIE_SECURE=True
 export KUMA_STATIC_URL=https://developer.cdn.mozilla.net/static/

--- a/apps/mdn/mdn-aws/k8s/regions/portland/stage.mdn-mm.moz.works.sh
+++ b/apps/mdn/mdn-aws/k8s/regions/portland/stage.mdn-mm.moz.works.sh
@@ -116,6 +116,7 @@ export KUMA_MAINTENANCE_MODE=False
 export KUMA_MEDIA_ROOT=/mdn/www
 export KUMA_MEDIA_URL=https://mm-cdn.mdn.moz.works/media/
 export KUMA_PROTOCOL=https://
+export KUMA_SECURE_HSTS_SECONDS=10
 export KUMA_SERVE_LEGACY=True
 export KUMA_SESSION_COOKIE_SECURE=True
 export KUMA_STATIC_URL=https://mm-cdn.mdn.moz.works/static/

--- a/apps/mdn/mdn-aws/k8s/regions/portland/stage.sh
+++ b/apps/mdn/mdn-aws/k8s/regions/portland/stage.sh
@@ -116,6 +116,7 @@ export KUMA_MAINTENANCE_MODE=False
 export KUMA_MEDIA_ROOT=/mdn/www
 export KUMA_MEDIA_URL=/media/
 export KUMA_PROTOCOL="https://"
+export KUMA_SECURE_HSTS_SECONDS=63072000
 export KUMA_SERVE_LEGACY=True
 export KUMA_SESSION_COOKIE_SECURE=True
 export KUMA_STATIC_URL=/static/


### PR DESCRIPTION
This PR adds the ability to configure the Kuma-based deployments with `SECURE_HSTS_SECONDS` (as recently added in https://github.com/mozilla/kuma/pull/4429).