### PR TITLE
add Makefile commands for doing rolling updates

### DIFF
--- a/apps/mdn/mdn-aws/k8s/Makefile
+++ b/apps/mdn/mdn-aws/k8s/Makefile
@@ -177,31 +177,29 @@ k8s-services: k8s-web-svc k8s-api-svc k8s-kumascript-svc
 k8s-delete-services: k8s-delete-web-svc k8s-delete-api-svc \
 					 k8s-delete-kumascript-svc
 
-k8s-deployments: k8s-web k8s-api k8s-kumascript k8s-celery
+k8s-deployments: k8s-kuma-deployments k8s-kumascript-deployments
 
-k8s-delete-deployments: k8s-delete-web k8s-delete-api \
- 						k8s-delete-kumascript k8s-delete-celery
+k8s-delete-deployments: k8s-delete-kuma-deployments \
+						k8s-delete-kumascript-deployments
 
-k8s-kuma-rollout:
-	kubectl -n ${K8S_NAMESPACE} set image deploy ${WEB_NAME} \
-		${WEB_NAME}=${KUMA_IMAGE}:${KUMA_IMAGE_TAG}
-	kubectl -n ${K8S_NAMESPACE} set image deploy ${API_NAME} \
-		${API_NAME}=${KUMA_IMAGE}:${KUMA_IMAGE_TAG}
-	kubectl -n ${K8S_NAMESPACE} set image deploy ${CELERY_WORKERS_NAME} \
-		${CELERY_WORKERS_NAME}=${KUMA_IMAGE}:${KUMA_IMAGE_TAG}
-	kubectl -n ${K8S_NAMESPACE} set image deploy ${CELERY_BEAT_NAME} \
-		${CELERY_BEAT_NAME}=${KUMA_IMAGE}:${KUMA_IMAGE_TAG}
-	kubectl -n ${K8S_NAMESPACE} set image deploy ${CELERY_CAM_NAME} \
-		${CELERY_CAM_NAME}=${KUMA_IMAGE}:${KUMA_IMAGE_TAG}
+k8s-kuma-deployments: k8s-web k8s-api k8s-celery
+
+k8s-delete-kuma-deployments: k8s-delete-web k8s-delete-api k8s-delete-celery
+
+k8s-kumascript-deployments: k8s-kumascript
+
+k8s-delete-kumascript-deployments: k8s-delete-kumascript
+
+k8s-rollout-status: k8s-kuma-rollout-status k8s-kumascript-rollout-status
+
+k8s-kuma-rollout-status:
 	kubectl -n ${K8S_NAMESPACE} rollout status deploy ${WEB_NAME}
 	kubectl -n ${K8S_NAMESPACE} rollout status deploy ${API_NAME}
 	kubectl -n ${K8S_NAMESPACE} rollout status deploy ${CELERY_WORKERS_NAME}
 	kubectl -n ${K8S_NAMESPACE} rollout status deploy ${CELERY_BEAT_NAME}
 	kubectl -n ${K8S_NAMESPACE} rollout status deploy ${CELERY_CAM_NAME}
 
-k8s-kumascript-rollout:
-	kubectl -n ${K8S_NAMESPACE} set image deploy ${KUMASCRIPT_NAME} \
-		${KUMASCRIPT_NAME}=${KUMASCRIPT_IMAGE}:${KUMASCRIPT_IMAGE_TAG}
+k8s-kumascript-rollout-status:
 	kubectl -n ${K8S_NAMESPACE} rollout status deploy ${KUMASCRIPT_NAME}
 
 ### end core tasks
@@ -399,4 +397,7 @@ k8s-delete-celery-cam:
 		k8s-web k8s-delete-web k8s-api k8s-delete-api k8s-kumascript \
 		k8s-delete-kumascript k8s-celery k8s-delete-celery k8s-celery-workers \
 		k8s-delete-celery-workers k8s-celery-beat k8s-delete-celery-beat \
-		k8s-celery-cam k8s-delete-celery-cam
+		k8s-celery-cam k8s-delete-celery-cam k8s-kuma-deployments \
+		k8s-delete-kuma-deployments k8s-kumascript-deployments \
+		k8s-delete-kumascript-deployments k8s-rollout-status \
+		k8s-kuma-rollout-status k8s-kumascript-rollout-status


### PR DESCRIPTION
This PR updates the `Makefile` with new commands for doing rolling updates (it replaces the ideas from #496). For example, to perform rolling updates on all of the Kuma-based deployments when there is a new Docker image for Kuma:
```
# Assumes you're starting at the root of the infra repo
cd apps/mdn/mdn-aws/k8s
source regions/portland/stage.mdn-mm.moz.works.sh
export KUMA_IMAGE_TAG=`git rev-parse --short HEAD`
# You can make changes to any number of additional env variables that affect the Kuma-based deployments
make k8s-kuma-deployments
```
and to check the status of all of the Kuma-based rollouts:
```
make k8s-kuma-rollout-status
```
To perform rolling updates on all of the Kumascript-based deployments (there's only one currently of course) when there is a new Docker image for Kumascript:
```
# Assumes you're starting at the root of the infra repo
cd apps/mdn/mdn-aws/k8s
source regions/portland/stage.mdn-mm.moz.works.sh
export KUMASCRIPT_IMAGE_TAG=`git rev-parse --short HEAD`
# Again, you can make changes to any number of additional env variables that affect the Kumascript-based deployments
make k8s-kumascript-deployments
```
and to check the status of all of the Kumascript-based rollouts:
```
make k8s-kumascript-rollout-status
```