### PR TITLE
Add an MDN initialization checklist

### DIFF
--- a/apps/mdn/mdn-aws/docs/init-checklist.md
+++ b/apps/mdn/mdn-aws/docs/init-checklist.md
@@ -1,29 +1,128 @@
 When initializing a new MDN deployment, there are several items that may need
 to be configured.
 
-# Database
+# Set Deployment Environment
 
-* Sample DB or Anon DB or Prod Backup
+The environment settings for a deployment may need to be customized for the
+desired domain name and use cases. See the existing environments for ideas
+on what may need to be changed.
 
-# Configuration
+* [ ] Customize the deployment settings
 
-* GitHub Auth (optional, see [Enable GitHub Auth](https://kuma.readthedocs.io/en/latest/installation.html#enable-github-auth-optional))
-* Site
-* Constance
-  * ``KUMASCRIPT_TIMEOUT`` - non-zero
-  * ``KUMA_WIKI_IFRAME_ALLOWED_HOSTS`` - needs the planned domain name
-* Waffle
+# Load a Database
 
-# Search
+A database is needed for an MDN deployment. We support MySQL RDS as the
+database engine. There are three options for the database backup:
 
-* Create and populate index
+* Sample Database - located at
+  https://mdn-downloads.s3-us-west-2.amazonaws.com/mdn_sample_db.sql.gz.
+  It is loaded with content from production, and is periodically updated.
+  It is customized for local development.
+* Anonymous Database - This is a copy of the production database, with some
+  sensitive data purged, and other user data such as emails anonymoized.
+  It is used to test code changes that need the entire data set.
+* Production Backup - This is a copy of the production database. It contains
+  user data such as email addresses, and should be handled securely. One
+  option is to load a recent backup and then anonymize it.
 
-# Rendered Pages
+* [ ] Load the desired database
+* [ ] (Optional) Run anonymization script
+* [ ] (Optional) Run anonymization confirmation script
 
-* Ensure KS is enabled and reachable
-* Render the unrendered pages
+# Configure the Database
 
-# Generate Files
+* [ ] Set the site name:
+  ```
+  ./manage.py set_default_site --name=site-name.moz.works --domain=site-name.moz.works
+  ```
+* [ ] Add a password-backed admin account:
+  ```
+  ./manage.py ihavepower username --password 'P@ssW0rd'
+  ```
+* [ ] (Optional) Configure GitHub Auth.
+   A domain-specific GitHub OAuth application must be created to use GitHub
+   auth. This can be a MDN staff member for short-term deployments, but should
+   be created by *TKTKTK* for long-term production services. This will allow
+   you to login and access the admin using your GitHub account.
+   See [Enable GitHub Auth](https://kuma.readthedocs.io/en/latest/installation.html#enable-github-auth-optional))
+* [ ] (Optional) Disable the password-backed admin account, or give it an
+  unused password
+* [ ] Set Constance settings. This can be done from the Django admin
+  (*todo* - update to django-constance 2.0, which includes
+  [management commands](https://django-constance.readthedocs.io/en/latest/#command-line)
+  to view and set Constance settings).
+  Suggested settings to customize:
+  - ``KUMASCRIPT_TIMEOUT`` - Set to non-zero (like ``30``) to enable
+    KumaScript rendering
+  - ``KUMA_WIKI_IFRAME_ALLOWED_HOSTS`` - Add the planned demo domain name to
+    the regex so that samples will be visible
+* [ ] (Optional) Set Waffle flags and switches. The database include some
+  waffle flags and switches, but recent changes in production may be
+  different, or you may want different values for your testing environment.
 
-* ``humans.txt`` - ``./manange.py make_humans``
-* sitemaps - ``./manage.py make_sitemaps``
+# Populate Search (Optional)
+
+The database may include indexes, but these aren't reflected in the new
+deployment's ElasticSearch instance. Use the Django admin and the
+[development instructions](https://kuma.readthedocs.io/en/latest/elasticsearch.html#indexing-documents)
+to create a new index.
+
+* [ ] Create and populate index
+
+# Pre-Render Pages (Optional)
+
+Wiki pages are rendered with KumaScript, and then "bleached" to remove
+dangerous HTML. Rendering is not available in Maintenance Mode, so it may
+be useful to pre-render pages before going into that mode. If you are
+changing settings like the sample domain, you may want to re-render already
+rendered documents.
+
+This Django shell script (``./manage.py shell_plus``) can be used to force
+asynchronous rendering of pages, using the celery workers:
+
+```
+from kuma.wiki.tasks import render_document
+import time
+all_pages = Document.objects.exclude(is_redirect=True)
+unrendered_pages = all_pages.filter(Q(rendered_html__isnull=True)|Q(rendered_html="")).exclude(is_redirect=True)
+to_render = unrendered_pages  # or all_pages
+total = to_render.count()
+for doc_id in to_render.values_list('id', flat=True):
+    render_document.delay(doc_id, cache_control='no-cache', base_url=None, force=True)
+
+count = total
+stalled = 0
+while count:
+    print ("%d of %d remaining" % (count, total))
+    last_count = count
+    time.sleep(5)
+    count = to_render.count()
+    if count == last_count:
+        if stalled > 3:
+            doc_ids = to_render.values_list('id', flat=True)
+            print("Rendering stalled. Unrendered IDs: %s" % doc_ids)
+            break
+        else:
+            stalled += 1
+    else:
+        stalled = 0
+
+if count == 0:
+    print("Done!")
+```
+
+
+* [ ] Render the desired pages
+
+# Generate files
+
+Some files served by Django must be generated first:
+
+* [ ] Generate ``humans.txt``:
+  ```
+  ./manange.py make_humans
+  ```
+* [ ] Generate sitemaps:
+  ```
+  ./manage.py make_sitemaps
+  ```

--- a/apps/mdn/mdn-aws/docs/init-checklist.md
+++ b/apps/mdn/mdn-aws/docs/init-checklist.md
@@ -67,7 +67,7 @@ deployment's ElasticSearch instance. Use the Django admin and the
 [development instructions](https://kuma.readthedocs.io/en/latest/elasticsearch.html#indexing-documents)
 to create a new index.
 
-* [ ] Create and populate index
+* [ ] Create, populate, and promote index
 
 # Pre-Render Pages (Optional)
 
@@ -78,14 +78,14 @@ changing settings like the sample domain, you may want to re-render already
 rendered documents.
 
 This Django shell script (``./manage.py shell_plus``) can be used to force
-asynchronous rendering of pages, using the celery workers:
+asynchronous rendering of unrendered pages, using the celery workers:
 
 ```
 from kuma.wiki.tasks import render_document
 import time
 all_pages = Document.objects.exclude(is_redirect=True)
 unrendered_pages = all_pages.filter(Q(rendered_html__isnull=True)|Q(rendered_html="")).exclude(is_redirect=True)
-to_render = unrendered_pages  # or all_pages
+to_render = unrendered_pages
 total = to_render.count()
 for doc_id in to_render.values_list('id', flat=True):
     render_document.delay(doc_id, cache_control='no-cache', base_url=None, force=True)

--- a/apps/mdn/mdn-aws/docs/init-checklist.md
+++ b/apps/mdn/mdn-aws/docs/init-checklist.md
@@ -1,0 +1,29 @@
+When initializing a new MDN deployment, there are several items that may need
+to be configured.
+
+# Database
+
+* Sample DB or Anon DB or Prod Backup
+
+# Configuration
+
+* GitHub Auth (optional, see [Enable GitHub Auth](https://kuma.readthedocs.io/en/latest/installation.html#enable-github-auth-optional))
+* Site
+* Constance
+  * ``KUMASCRIPT_TIMEOUT`` - non-zero
+  * ``KUMA_WIKI_IFRAME_ALLOWED_HOSTS`` - needs the planned domain name
+* Waffle
+
+# Search
+
+* Create and populate index
+
+# Rendered Pages
+
+* Ensure KS is enabled and reachable
+* Render the unrendered pages
+
+# Generate Files
+
+* ``humans.txt`` - ``./manange.py make_humans``
+* sitemaps - ``./manage.py make_sitemaps``

--- a/apps/mdn/mdn-aws/docs/maintenance-mode-checklist.md
+++ b/apps/mdn/mdn-aws/docs/maintenance-mode-checklist.md
@@ -60,6 +60,10 @@ using a command like:
 py.test --maintenance-mode tests/functional tests/redirects --base-url https://mdn-mm.moz.works --driver Chrome --driver-path /path/to/chromedriver
 ```
 
+Some tests will fail the first time they are run against a server with cold
+caches. Some tests are flakey, and will intermittantly fail.  If a test
+passes once in three tries, we consider it a success.
+
 * [ ] Functional tests pass
 
 These check that disabled endpoints redirect to the maintenance page, and that

--- a/apps/mdn/mdn-aws/docs/maintenance-mode-checklist.md
+++ b/apps/mdn/mdn-aws/docs/maintenance-mode-checklist.md
@@ -72,7 +72,7 @@ other pages are OK. It duplicates the Manual Sanity Check.
 * [ ] https://mdn-mm-demos.moz.works/en-US/docs/Learn/CSS/Styling_text/Fundamentals$samples/Color - 200, sample as a stand-alone page
 * [ ] https://mdn-mm-demos.moz.works/files/12984/web-font-example.png - 200, PNG of some "Hipster ipsum" text
 * [ ] https://mdn-mm.moz.works/@api/deki/files/3613/=hut.jpg - 200, image of a hat
-* [ ] https://mdn-mm.moz.works/admin/ - 404 in maintenance mode
+* [ ] https://mdn-mm.moz.works/admin/ - Redirects to maintenance mode page
 * [ ] https://mdn-mm.moz.works/contribute.json - 200, project info
 * [ ] https://mdn-mm.moz.works/diagrams/workflow/workflow.svg - 200, SVG with images
 * [ ] https://mdn-mm.moz.works/en-US/dashboards/macros - 200, list of macros and page counts

--- a/apps/mdn/mdn-aws/docs/maintenance-mode-checklist.md
+++ b/apps/mdn/mdn-aws/docs/maintenance-mode-checklist.md
@@ -11,14 +11,17 @@ This checklist uses these URLs:
 
 If you want a public-facing site, you'll need to generate
 content before putting the site in Maintenance Mode. The
-full steps are in *todo*, but here's the quick version:
+full steps are in init-checklist.md, but here's the quick version:
 
 * [ ] Load a recent (anonymized) backup
-* [ ] Enable GitHub auth (see [Enable GitHub Auth](https://kuma.readthedocs.io/en/latest/installation.html#enable-github-auth-optional))
-* [ ] Render unrendered pages
-* [ ] Add https://mdn-mm-demos.moz.works to constance ``KUMA_WIKI_IFRAME_ALLOWED_HOSTS``
-* [ ] Generate sitemaps
+* [ ] Enable GitHub auth (optional, to use Django admin for config)
+* [ ] Configure the Site
+* [ ] Set required Constance values (``KUMASCRIPT_TIMEOUT``, ``KUMA_WIKI_IFRAME_ALLOWED_HOSTS``)
+* [ ] Set desired Waffle flags
 * [ ] Generate the search index
+* [ ] Render unrendered pages (optional)
+* [ ] Generate sitemaps
+* [ ] Generate humans.txt
 * [ ] Restart web servers, etc. in Maintenance Mode
 
 # Manual Sanity Check


### PR DESCRIPTION
Add an initialization checklist with steps from setting up the maintenance mode test.

Also standardize on dashes, not underlines.

I'll add more detail later, but I wanted to capture steps from #498 as we encounter them.