### PR TITLE
add rollback & history commands (plus add kc alias to dev.sh)

### DIFF
--- a/apps/mdn/mdn-aws/k8s/Makefile
+++ b/apps/mdn/mdn-aws/k8s/Makefile
@@ -210,6 +210,30 @@ k8s-kuma-rollout-status:
 k8s-kumascript-rollout-status:
 	kubectl -n ${K8S_NAMESPACE} rollout status deploy ${KUMASCRIPT_NAME}
 
+k8s-rollback: k8s-kuma-rollback k8s-kumascript-rollback
+
+k8s-kuma-rollback:
+	kubectl -n ${K8S_NAMESPACE} rollout undo deploy ${WEB_NAME}
+	kubectl -n ${K8S_NAMESPACE} rollout undo deploy ${API_NAME}
+	kubectl -n ${K8S_NAMESPACE} rollout undo deploy ${CELERY_WORKERS_NAME}
+	kubectl -n ${K8S_NAMESPACE} rollout undo deploy ${CELERY_BEAT_NAME}
+	kubectl -n ${K8S_NAMESPACE} rollout undo deploy ${CELERY_CAM_NAME}
+
+k8s-kumascript-rollback:
+	kubectl -n ${K8S_NAMESPACE} rollout undo deploy ${KUMASCRIPT_NAME}
+
+k8s-history: k8s-kuma-history k8s-kumascript-history
+
+k8s-kuma-history:
+	kubectl -n ${K8S_NAMESPACE} rollout history deploy ${WEB_NAME}
+	kubectl -n ${K8S_NAMESPACE} rollout history deploy ${API_NAME}
+	kubectl -n ${K8S_NAMESPACE} rollout history deploy ${CELERY_WORKERS_NAME}
+	kubectl -n ${K8S_NAMESPACE} rollout history deploy ${CELERY_BEAT_NAME}
+	kubectl -n ${K8S_NAMESPACE} rollout history deploy ${CELERY_CAM_NAME}
+
+k8s-kumascript-history:
+	kubectl -n ${K8S_NAMESPACE} rollout history deploy ${KUMASCRIPT_NAME}
+
 ### end core tasks
 ###############################
 

--- a/apps/mdn/mdn-aws/k8s/regions/portland/dev.sh
+++ b/apps/mdn/mdn-aws/k8s/regions/portland/dev.sh
@@ -8,6 +8,9 @@ export TARGET_ENVIRONMENT=dev
 export K8S_NAMESPACE=mdn-${TARGET_ENVIRONMENT}
 export AWS_REGION=us-west-2
 
+# Define an alias for kubectl for convenience.
+alias kc="kubectl -n ${K8S_NAMESPACE}"
+
 # Note PVs are available within ALL namespaces, so delimit them with
 # the name of the target environment.
 export SHARED_PV_NAME=mdn-shared-${TARGET_ENVIRONMENT}


### PR DESCRIPTION
Add rollback and history commands. Examples:

- Rollback most recent deployment of new Kuma image only:
```
export KUMA_IMAGE_TAG=<short-git-hash>
make k8s-kuma-deployments
...
make k8s-kuma-rollback
```

- Rollback most recent deployment of new Kumascript image only:
```
export KUMASCRIPT_IMAGE_TAG=<short-git-hash>
make k8s-kumascript-deployments
...
make k8s-kumascript-rollback
```

- Rollback most recent deployment of both Kuma and Kumascript images:
```
export KUMA_IMAGE_TAG=<short-git-hash>
export KUMASCRIPT_IMAGE_TAG=<short-git-hash>
make k8s-deployments
...
make k8s-rollback
```

- View roll-out history of the Kuma-image-based deployments:
```
make k8s-kuma-history
```

- View roll-out history of the Kumascript-image-based deployment:
```
make k8s-kumascript-history
```

- View roll-out history of the Kuma and Kumascript-image-based deployments:
```
make k8s-history
```