### PR TITLE
[snippets-stats] Update configuration.

### DIFF
--- a/apps/snippets-stats/scale.sh
+++ b/apps/snippets-stats/scale.sh
@@ -5,4 +5,4 @@ check_meao_env
 
 deis limits:set cmd=128M/300M -a snippets-stats
 deis limits:set cmd=50m/100m --cpu -a snippets-stats
-deis autoscale:set cmd --min=5 --max=10 --cpu-percent=80 -a snippets-stats
+deis autoscale:set cmd --min=3 --max=10 --cpu-percent=80 -a snippets-stats

--- a/apps/snippets-stats/setup.sh
+++ b/apps/snippets-stats/setup.sh
@@ -14,13 +14,17 @@ setup_monitors() {
         "Snippets Stats Frankfurt" \
         "https://snippets-stats.frankfurt.moz.works" \
         "AWS_EU_CENTRAL_1"
+
+    create_monitor_if_missing \
+        "Snippets Stats Portland" \
+        "https://snippets-stats.portland.moz.works" \
+        "AWS_US_WEST_2"
 }
 
 deis create snippets-stats --no-remote
 deis perms:create jenkins -a snippets-stats
 deis domains:add snippets-stats.moz.works -a snippets-stats
 
-deis config:set ALLOWED_HOSTS=\* -a snippets-stats
 kubectl -n snippets-stats apply -f ./k8s/snippets-stats-nodeport.yaml
 deis pull mozmeao/snippets-stats:37727e -a snippets-stats
 

--- a/apps/snippets-stats/teardown.sh
+++ b/apps/snippets-stats/teardown.sh
@@ -7,4 +7,4 @@ deis apps:destroy -a snippets-stats --confirm snippets-stats
 
 neres delete-monitor $(get_newrelic_monitor_id "Snippets Stats Tokyo")
 neres delete-monitor $(get_newrelic_monitor_id "Snippets Stats Frankfurt")
-
+neres delete-monitor $(get_newrelic_monitor_id "Snippets Stats Portland")


### PR DESCRIPTION
 - Reduce autoscale to min 3. Under normal load 3 per cluster are enough.
 - Removed ALLOWED_HOSTS configuration, not a Django app.
 - Add Portland NR Synthetics monitor.

Part of #538 