### PR TITLE
Set New Relic license key for kumascript server

### DIFF
--- a/apps/mdn/mdn-aws/k8s/kumascript.deploy.yaml.j2
+++ b/apps/mdn/mdn-aws/k8s/kumascript.deploy.yaml.j2
@@ -54,7 +54,7 @@ spec:
               value: "{{ NEW_RELIC_LOG }}"
             - name: NEW_RELIC_BROWSER_MONITOR_ENABLE
               value: "{{ NEW_RELIC_BROWSER_MONITOR_ENABLE }}"
-            - name: NEW_RELIC_LICENSE_KEY
+            - name: new_relic__license_key
               valueFrom:
                 secretKeyRef:
                   name: newrelic-secrets


### PR DESCRIPTION
The KumaScript server looks at it's own configuration to decide if it will load New Relic, so we need to use ``new_relic__license_key`` for the environment variable name.