### PR TITLE
celery: use long options, send log to stdout

### DIFF
--- a/apps/mdn/mdn-aws/k8s/celery.beat.deploy.yaml.j2
+++ b/apps/mdn/mdn-aws/k8s/celery.beat.deploy.yaml.j2
@@ -4,3 +4,4 @@
           args:
             - celerybeat
             - "--loglevel=INFO"
+            - "--logfile=/dev/stdout"

--- a/apps/mdn/mdn-aws/k8s/celery.cam.deploy.yaml.j2
+++ b/apps/mdn/mdn-aws/k8s/celery.cam.deploy.yaml.j2
@@ -5,3 +5,4 @@
             - celerycam
             - "--freq=2.0"
             - "--loglevel=INFO"
+            - "--logfile=/dev/stdout"

--- a/apps/mdn/mdn-aws/k8s/celery.workers.deploy.yaml.j2
+++ b/apps/mdn/mdn-aws/k8s/celery.workers.deploy.yaml.j2
@@ -8,5 +8,6 @@
             - worker
             - "--events"
             - "--autoreload"
+            - "--logfile=/dev/stdout"
             - "--concurrency={{ CELERY_WORKERS_CONCURRENCY }}"
-            - "-Q {{ CELERY_WORKERS_QUEUES }}"
+            - "--queues={{ CELERY_WORKERS_QUEUES }}"


### PR DESCRIPTION
* The celery workers are sending output to the ``stderr``, but Papertrail reads ``stdout``.
* The ``mdn_purgable`` queue appears to be filling up. There's a suspicious space in the output captured by kubernetes:

```
 -------------- celery@celery-worker-2321427860-199xf v3.1.20 (Cipater)
---- **** ----- 
--- * ***  * -- Linux-4.4.65-k8s-x86_64-with-Ubuntu-16.04-xenial
-- * - **** --- 
- ** ---------- [config]
- ** ---------- .> app:         default:0x7f1fd4449bd0 (djcelery.loaders.DjangoLoader)
- ** ---------- .> transport:   redis://mdn-redis-prod.cache.amazonaws.com:6379/0
- ** ---------- .> results:     cache+memcached://mdn-memcached-prod.cache.amazonaws.com:11121/
- *** --- * --- .> concurrency: 4 (prefork)
-- ******* ---- 
--- ***** ----- [queues]
 -------------- .>  mdn_purgeable   exchange= mdn_purgeable(direct) key= mdn_purgeable
                .> celery           exchange=celery(direct) key=celery
                .> mdn_emails       exchange=mdn_emails(direct) key=mdn_emails
                .> mdn_search       exchange=mdn_search(direct) key=mdn_search
                .> mdn_wiki         exchange=mdn_wiki(direct) key=mdn_wiki
```

That space extra space in ``.>  mdn_purgeable`` may be due to parsing the ``-Q`` option, so trying the long option.