### PR TITLE
use stage.mdn.moz.works for origin domain

### DIFF
--- a/apps/mdn/mdn-aws/infra/mdn-cdn/mdn_cdn.tf
+++ b/apps/mdn/mdn-aws/infra/mdn-cdn/mdn_cdn.tf
@@ -18,7 +18,7 @@ module "mdn-cloudfront-stage" {
     aliases = ["stage-cdn.mdn.mozilla.net", "stage-cdn.mdn.moz.works"]
     comment = "Stage CDN for AWS-hosted MDN"
     distribution_name = "MDNStageCDN"
-    domain_name = "developer.allizom.org"
+    domain_name = "stage.mdn.moz.works"
 }
 
 module "mdn-cloudfront-prod" {


### PR DESCRIPTION
I can apply a similar change to the prod cdn if we prefer.