### PR TITLE
prod configs for go-live day

### DIFF
--- a/apps/mdn/mdn-aws/k8s/regions/portland/prod.mm.sh
+++ b/apps/mdn/mdn-aws/k8s/regions/portland/prod.mm.sh
@@ -97,7 +97,7 @@ export KUMASCRIPT_MEMORY_LIMIT=8Gi
 export KUMASCRIPT_MEMORY_REQUEST=2Gi
 
 export KUMA_IMAGE=quay.io/mozmar/kuma
-export KUMA_IMAGE_TAG=5e3da90
+export KUMA_IMAGE_TAG=87984cd
 export KUMA_IMAGE_PULL_POLICY=IfNotPresent
 # "KUMA_MOUNT_PATH" sets the mount path for the claim of the shared volume.
 export KUMA_MOUNT_PATH=/mdn

--- a/apps/mdn/mdn-aws/k8s/regions/portland/prod.mm.sh
+++ b/apps/mdn/mdn-aws/k8s/regions/portland/prod.mm.sh
@@ -72,14 +72,14 @@ export CELERY_WORKERS_CONCURRENCY=4
 export CELERY_WORKERS_QUEUES=mdn_purgeable,mdn_search,mdn_emails,mdn_wiki,celery
 
 export CELERY_BEAT_NAME=celery-beat
-export CELERY_BEAT_REPLICAS=1
+export CELERY_BEAT_REPLICAS=0
 export CELERY_BEAT_CPU_LIMIT=1
 export CELERY_BEAT_CPU_REQUEST=250m
 export CELERY_BEAT_MEMORY_LIMIT=2Gi
 export CELERY_BEAT_MEMORY_REQUEST=256Mi
 
 export CELERY_CAM_NAME=celery-cam
-export CELERY_CAM_REPLICAS=1
+export CELERY_CAM_REPLICAS=0
 export CELERY_CAM_CPU_LIMIT=1
 export CELERY_CAM_CPU_REQUEST=250m
 export CELERY_CAM_MEMORY_LIMIT=4Gi
@@ -116,7 +116,7 @@ export KUMA_EMAIL_BACKEND=django.core.mail.backends.smtp.EmailBackend
 export KUMA_ES_INDEX_PREFIX=mdnprod
 export KUMA_ES_LIVE_INDEX=True
 export KUMA_LEGACY_ROOT=/mdn/www
-export KUMA_MAINTENANCE_MODE=False
+export KUMA_MAINTENANCE_MODE=True
 export KUMA_MEDIA_ROOT=/mdn/www
 export KUMA_MEDIA_URL=https://cdn.mdn.mozilla.net/media/
 export KUMA_PROTOCOL="https://"

--- a/apps/mdn/mdn-aws/k8s/regions/portland/prod.sh
+++ b/apps/mdn/mdn-aws/k8s/regions/portland/prod.sh
@@ -97,7 +97,7 @@ export KUMASCRIPT_MEMORY_LIMIT=8Gi
 export KUMASCRIPT_MEMORY_REQUEST=2Gi
 
 export KUMA_IMAGE=quay.io/mozmar/kuma
-export KUMA_IMAGE_TAG=5e3da90
+export KUMA_IMAGE_TAG=87984cd
 export KUMA_IMAGE_PULL_POLICY=IfNotPresent
 # "KUMA_MOUNT_PATH" sets the mount path for the claim of the shared volume.
 export KUMA_MOUNT_PATH=/mdn


### PR DESCRIPTION
We have two configs for "go-live" day:
- `prod.mm.sh` is for the initial maintenance-mode deployment to production, during the transition from SCL3 (which will be in maintenance mode) to AWS
- `prod.sh`, which removes maintenance mode, is intended for deployment after the move to AWS has been completed and seems stable

I'm switching to `cdn.mdn.mozilla.net` for the **cdn** domain (from `developer.cdn.mozilla.net`) and staying with `mdn.mozillademos.org` for the **untrusted** domain.