### PR TITLE
change imagePullPolicy for MDN cronjobs

### DIFF
--- a/apps/mdn/mdn-aws/k8s/Makefile
+++ b/apps/mdn/mdn-aws/k8s/Makefile
@@ -144,7 +144,7 @@ export SYNC_REMOTE_DIR ?= "/backups/efs/"
 
 export BACKUP_CONTAINER_NAME ?= mdn-backup
 export SYNC_FROM_S3_CONTAINER_NAME ?= mdn-sync
-export BACKUP_IMAGE ?= quay.io/mozmar/mdn-backup:latest
+export BACKUP_IMAGE ?= quay.io/mozmar/mdn-backup:758c79a0fde3
 # cronjob syntax here: https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/
 export BACKUP_SERVICE_SCHEDULE ?= "@hourly"
 export SYNC_FROM_S3_SCHEDULE ?= "@hourly"

--- a/apps/mdn/mdn-aws/k8s/mdn-backup-cron.yaml.j2
+++ b/apps/mdn/mdn-aws/k8s/mdn-backup-cron.yaml.j2
@@ -14,6 +14,7 @@ spec:
           containers:
             - name: {{ BACKUP_CONTAINER_NAME }}
               image: {{ BACKUP_IMAGE }}
+              imagePullPolicy: IfNotPresent
               volumeMounts:
                 - mountPath: {{ BACKUP_MOUNT_DIR }}
                   name: {{ SHARED_PVC_NAME }}

--- a/apps/mdn/mdn-aws/k8s/mdn-sync-from-s3-cron.yaml.j2
+++ b/apps/mdn/mdn-aws/k8s/mdn-sync-from-s3-cron.yaml.j2
@@ -14,6 +14,7 @@ spec:
           containers:
             - name: {{ SYNC_FROM_S3_CONTAINER_NAME }}
               image: {{ BACKUP_IMAGE }}
+              imagePullPolicy: IfNotPresent
               volumeMounts:
                 - mountPath: {{ BACKUP_MOUNT_DIR }}
                   name: {{ SHARED_PVC_NAME }}


### PR DESCRIPTION
quay.io had a minor outage this morning, which prevented the cronjobs from starting. Instead of always pulling a new image, only pull if the image is not present. We'll have to get better about tagging images in the future, but I think the `latest` tag is ok for now.

SCL3 and prod cronjobs updated in the `mdn-prod` namespace.