### PR TITLE
 tf for creating MDN Frankfurt maint mode resources (without RDS) 

### DIFF
--- a/apps/mdn/mdn-aws/infra/multi_region/frankfurt/provision.sh
+++ b/apps/mdn/mdn-aws/infra/multi_region/frankfurt/provision.sh
@@ -1,0 +1,17 @@
+#!/bin/bash -e
+
+export TERRAFORM_ENV="frankfurt"
+export MDN_PROVISIONING_REGION="us-west-2"
+export TF_VAR_region="${MDN_PROVISIONING_REGION}"
+export TF_VAR_subnets="subnet-10685f78,subnet-10685f78"
+# nodes.frankfurt.moz.works
+export TF_VAR_nodes_security_group="sg-e73a4e8c"
+export TF_VAR_vpc_id="vpc-4d036a25"
+export TF_VAR_vpc_cidr="172.20.0.0/16"
+
+# Apply Terraform
+# NOTE! since Frankfurt uses an RDS read replica and will only host prod resources,
+#       we call out each resource below via -target=...
+cd ../tf && ./common.sh -target=module.efs-prod -target=module.redis-prod -target=module.memcached-prod
+
+

--- a/apps/mdn/mdn-aws/infra/multi_region/frankfurt/provision.sh
+++ b/apps/mdn/mdn-aws/infra/multi_region/frankfurt/provision.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 
 export TERRAFORM_ENV="frankfurt"
-export MDN_PROVISIONING_REGION="us-west-2"
+export MDN_PROVISIONING_REGION="eu-central-1"
 export TF_VAR_region="${MDN_PROVISIONING_REGION}"
 export TF_VAR_subnets="subnet-10685f78,subnet-10685f78"
 # nodes.frankfurt.moz.works

--- a/apps/mdn/mdn-aws/infra/multi_region/tf/common.sh
+++ b/apps/mdn/mdn-aws/infra/multi_region/tf/common.sh
@@ -31,6 +31,7 @@ setup_tf_envs() {
     # this MUST be run in the dir that this file resides in
     set +e
     terraform env new portland
+    terraform env new frankfurt
     set -e
 }
 

--- a/apps/mdn/mdn-aws/infra/multi_region/tf/rds/rds.tf
+++ b/apps/mdn/mdn-aws/infra/multi_region/tf/rds/rds.tf
@@ -48,11 +48,11 @@ variable "mysql_backup_retention_days" {
 }
 
 variable "mysql_backup_window" {
-  default = "03:00-03:30"
+  default = "00:00-00:30"
 }
 
 variable "mysql_maintenance_window" {
-  default = "Sun:04:00-Sun:04:30"
+  default = "Sun:00:31-Sun:01:01"
 }
 
 variable "mysql_storage_encrypted" {


### PR DESCRIPTION
- changes to backup window and maintenance window were already set via the console the day after the MDN migration, updated here to get tf back in sync.