### PR TITLE
improve the "k8s-db-migration-job" Makefile command

### DIFF
--- a/apps/mdn/mdn-aws/k8s/Makefile
+++ b/apps/mdn/mdn-aws/k8s/Makefile
@@ -209,7 +209,7 @@ export DATADOG_API_KEY_BASE64 ?= $(shell echo -n "${DATADOG_API_KEY}" | base64)
 export DATADOG_REDIS_CONFIG ?= foo
 # note the base64 -w0, this prevents base64 from splitting the string w/ newlines
 # see https://kubernetes.io/docs/concepts/configuration/secret/
-export DATADOG_REDIS_CONFIG_BASE64 ?= $(shell echo -n "${DATADOG_REDIS_CONFIG}" | base64 -w0)
+export DATADOG_REDIS_CONFIG_BASE64 ?= $(shell echo -n "${DATADOG_REDIS_CONFIG}" | base64)
 
 
 ###############################
@@ -280,7 +280,7 @@ k8s-kuma-history:
 k8s-kumascript-history:
 	kubectl -n ${K8S_NAMESPACE} rollout history deploy ${KUMASCRIPT_NAME}
 
-k8s-db-migration-job:
+k8s-db-migration-job: k8s-delete-db-migration-job
 	env KUMA_NAME=mdn-db-migration \
 		KUMA_CPU_LIMIT=${WEB_CPU_LIMIT} \
 		KUMA_MEMORY_LIMIT=${WEB_MEMORY_LIMIT} \
@@ -289,6 +289,7 @@ k8s-db-migration-job:
 		KUMA_ALLOWED_HOSTS=${WEB_ALLOWED_HOSTS} \
 		NEW_RELIC_APP_NAME=${NEW_RELIC_WEB_NAME} \
 	j2 mdn-db-migration-job.yaml.j2 | kubectl apply -n ${K8S_NAMESPACE} -f -
+	env JOB_NAME=mdn-db-migration ./wait_for_job.sh
 
 k8s-delete-db-migration-job:
 	kubectl delete -n ${K8S_NAMESPACE} --ignore-not-found job mdn-db-migration

--- a/apps/mdn/mdn-aws/k8s/wait_for_job.sh
+++ b/apps/mdn/mdn-aws/k8s/wait_for_job.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+GET_JOB_JSON="kubectl -n ${K8S_NAMESPACE} get job ${JOB_NAME} -o json"
+
+check_job() {
+    echo "Checking..."
+    ${GET_JOB_JSON} | jq -e '(.status.succeeded != null) or (.status.failed != null)'
+}
+
+wait_for_job() {
+    echo "Waiting for job \"${JOB_NAME}\" to complete..."
+    until check_job
+    do
+      sleep 1
+    done
+    # Set the exit status based on the job's status.
+    if ${GET_JOB_JSON} | jq -e '(.status.succeeded != null)'
+    then
+        echo "Job \"${JOB_NAME}\" was successful!"
+        exit 0
+    else
+        echo "Job \"${JOB_NAME}\" failed!"
+        exit 1
+    fi;
+}
+
+# Wait until the job completes (succeeds or fails), and
+# return the exit status based on the status of the job.
+wait_for_job


### PR DESCRIPTION
This PR improves the `make k8s-db-migration-job` command:
* delete the previous `mdn-db-migration` job before starting new one
* wait until the `mdn-db-migration` job has completed and set the exit status based on job's status