### PR TITLE
bug 1414419: Vary MDN attachment CDN on ?revision=X

### DIFF
--- a/apps/mdn/mdn-aws/infra/mdn-cdn/cloudfront_attachments/cloudfront_attachments.tf
+++ b/apps/mdn/mdn-aws/infra/mdn-cdn/cloudfront_attachments/cloudfront_attachments.tf
@@ -34,7 +34,8 @@ resource "aws_cloudfront_distribution" "mdn-attachments-cf-dist" {
     viewer_protocol_policy = "redirect-to-https"
 
     forwarded_values {
-      query_string = false
+      query_string = true
+      query_string_cache_keys = ["revision"]
 
       cookies {
         forward = "none"


### PR DESCRIPTION
Vary the CloudFront cache on the querystring parameter ``revision``, which is used to refresh embeded live samples when the document is updated. See:

* [bug 1414419](https://bugzilla.mozilla.org/show_bug.cgi?id=1414419)
* [Configuring CloudFront to Cache Based on Query String Parameters](http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/QueryStringParameters.html)
* [Forwarded Values for cloudfront distribution](https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution.html#forwarded-values-arguments)