### PR TITLE
Kubernetes-based RDS backup tool

### DIFF
--- a/tools/aws/rds_backup_tool/Makefile
+++ b/tools/aws/rds_backup_tool/Makefile
@@ -13,7 +13,7 @@ export BACKUP_BUCKET ?= s3://meao-rds-backups/backups
 export DEBUG_MODE ?= false
 # automatically append month-year-date to new pod names
 export BACKUP_POD_SUFFIX ?= $(shell date +%F)
-export RDSBACKUP_IMAGE_TAG ?= dea4aed62d8f2d77c91c19022488e246fd1eded2
+export RDSBACKUP_IMAGE_TAG ?= bff26ed6aa0350e164cb3003fcae81f4ee9d9ff5
 export RDS_IMAGE ?= quay.io/mozmar/rdsbackup:${RDSBACKUP_IMAGE_TAG}
 # the command to use to render yaml and create pod in k8s
 export RENDER_POD_CMD ?= j2 rds_backup_pod.yaml.j2 | kubectl create -n ${K8S_NAMESPACE} -f -

--- a/tools/aws/rds_backup_tool/Makefile
+++ b/tools/aws/rds_backup_tool/Makefile
@@ -13,7 +13,7 @@ export BACKUP_BUCKET ?= s3://meao-rds-backups/backups
 export DEBUG_MODE ?= false
 # automatically append month-year-date to new pod names
 export BACKUP_POD_SUFFIX ?= $(shell date +%F)
-export RDSBACKUP_IMAGE_TAG ?= 9c50e47a276d536d6318ed2ebcda08d06ba50cb0
+export RDSBACKUP_IMAGE_TAG ?= dea4aed62d8f2d77c91c19022488e246fd1eded2
 export RDS_IMAGE ?= quay.io/mozmar/rdsbackup:${RDSBACKUP_IMAGE_TAG}
 # the command to use to render yaml and create pod in k8s
 export RENDER_POD_CMD ?= j2 rds_backup_pod.yaml.j2 | kubectl create -n ${K8S_NAMESPACE} -f -

--- a/tools/aws/rds_backup_tool/Makefile
+++ b/tools/aws/rds_backup_tool/Makefile
@@ -1,0 +1,36 @@
+# namespace where all backup pods run and secrets are installed
+export K8S_NAMESPACE ?= rds-backups
+# region global secrets, see README.md for more info
+export BACKUP_CONFIG_SECRETS ?= rds-backup-config
+# dir inside the container to use for backups
+export BACKUP_DIR ?= /backup
+# s3 bucket and subdir to push encrypted backups to
+# note: a subdirectory is automatically created with the name of the
+# database (DBNAME) to store a given DBNAME's backups.
+export BACKUP_BUCKET ?= s3://meao-rds-backups/backups
+# set this value to true to prevent the main backup script from running
+# used to get a shell in a container for debugging. See README.md for more info.
+export DEBUG_MODE ?= false
+# automatically append month-year-date to new pod names
+export BACKUP_POD_SUFFIX ?= $(shell date +%F)
+export RDSBACKUP_IMAGE_TAG ?= 9c50e47a276d536d6318ed2ebcda08d06ba50cb0
+export RDS_IMAGE ?= quay.io/mozmar/rdsbackup:${RDSBACKUP_IMAGE_TAG}
+# the command to use to render yaml and create pod in k8s
+export RENDER_POD_CMD ?= j2 rds_backup_pod.yaml.j2 | kubectl create -n ${K8S_NAMESPACE} -f -
+
+default:
+	echo "Please select a target"
+
+backup-mdn-prod-rr:
+	env DBTYPE=MYSQL \
+		DB_SECRETS_NAME=rds-backup-mdn-prod \
+		BACKUP_POD_NAME=mdn-prod-rr \
+	${RENDER_POD_CMD}
+
+backup-frankfurt:
+	env DBTYPE=PGSQL \
+		DB_SECRETS_NAME=rds-backup-frankfurt \
+		BACKUP_POD_NAME=frankfurt \
+	${RENDER_POD_CMD}
+
+.PHONY: mdn-backup frankfurt

--- a/tools/aws/rds_backup_tool/Makefile
+++ b/tools/aws/rds_backup_tool/Makefile
@@ -33,4 +33,3 @@ backup-frankfurt:
 		BACKUP_POD_NAME=frankfurt \
 	${RENDER_POD_CMD}
 
-.PHONY: mdn-backup frankfurt

--- a/tools/aws/rds_backup_tool/README.md
+++ b/tools/aws/rds_backup_tool/README.md
@@ -67,7 +67,7 @@ data:
 
 ### 1. Create the secret in Kubernetes
 
-Next, create the secret in Kubernets with the following command:
+Next, create the secret in Kubernetes with the following command:
 
 ```
 kubectl -n rds-backups create -f rds-backup-<dbname>-secrets-<region>.yaml

--- a/tools/aws/rds_backup_tool/README.md
+++ b/tools/aws/rds_backup_tool/README.md
@@ -26,7 +26,7 @@ data:
 
 - `AWS_ACCESS_KEY_ID` - access key ID for the user created above with access to the backup bucket
 - `AWS_SECRET_ACCESS_KEY` - secret key ID for the user created above with access to the backup bucket
-- `BACKUP_PASSWORD` - a password used for GPG symmetric encryption. It's up to the engineer installing this service to decide if each region uses a unique or shared password.
+- `BACKUP_PASSWORD` - a password used for OpenSSL AES 256 symmetric encryption. It's up to the engineer installing this service to decide if each region uses a unique or shared password.
 
 ```
 kubectl create namespace rds-backups
@@ -135,8 +135,16 @@ kubectl -n rds-backups get pods -a
 You can download the backup from either the AWS web console, or the AWS cli. 
 
 ```
-aws s3 cp s3://meao-rds-backups/backups/developer_mozilla_org/developer_mozilla_org.2017-11-17.sql.gz.gpg ./some_local_dir
-gpg decrypt developer_mozilla_org.2017-11-17.sql.gz.gpg | zcat | mysql ...
+aws s3 cp s3://meao-rds-backups/backups/developer_mozilla_org/developer_mozilla_org.2017-11-17.sql.gz.aes ./some_local_dir
+
+# stream directly to dbms
+openssl aes-256-cbc -in developer_mozilla_org.2017-11-17.sql.gz.aes -d -pass pass:foobar123 | zcat | mysql ...
+# decrypt to a file
+openssl aes-256-cbc -in developer_mozilla_org.2017-11-17.sql.gz.aes -d -pass pass:foobar123 -out developer_mozilla_org.2017-11-17.sql.gz
+
+
+
+
 ```
 
 ## Initial setup

--- a/tools/aws/rds_backup_tool/README.md
+++ b/tools/aws/rds_backup_tool/README.md
@@ -1,0 +1,187 @@
+# MozMEAO RDS backup tool
+
+The RDS backup tool allows us to export a MySQL/MariaDB/Postgres database from a pod running in Kubernetes. The running pod must already have connectivity to the VPC where the database is running. Backups are encrypted and pushed to a directory in an S3 bucket. Our current implemention uses an S3 bucket with lifecycle rules, which expires older backups to AWS Glacier after a certain number of days.
+
+> Note: You must rely on an external scheduler/cron, as this tool is designed to be used in K8s clusters without cronjobs enabled. 
+
+## <a name="per-region-setup"></a>Per-region setup
+
+Secrets for the RDS backup tool are located in our private repo in the `aws/rds_backup_secrets` directory. These secrets are shared for all backups configured in a given region. If the secrets have already been created in Kubernetes, you can most likely skip this section and continue on [to create a new backup target](#backup-target-setup).
+
+#### Region global secrets
+
+Create a file named `rds-backup-config-secrets-<region>.yaml` and populate with the following values:
+
+```
+apiVersion: v1
+kind: Secret
+metadata:
+  name: rds-backup-config
+type: Opaque
+data:
+  AWS_ACCESS_KEY_ID: value_in_bas64
+  AWS_SECRET_ACCESS_KEY: value_in_bas64
+  BACKUP_PASSWORD: value_in_bas64
+```
+
+- `AWS_ACCESS_KEY_ID` - access key ID for the user created above with access to the backup bucket
+- `AWS_SECRET_ACCESS_KEY` - secret key ID for the user created above with access to the backup bucket
+- `BACKUP_PASSWORD` - a password used for GPG symmetric encryption. It's up to the engineer installing this service to decide if each region uses a unique or shared password.
+
+```
+kubectl create namespace rds-backups
+kubectl -n rds-backups create -f rds-backup-config-secrets-<region>.yaml
+```
+
+## <a name="backup-target-setup"></a>Backup target setup
+
+To backup a particular database in the given region where the tool is installed, you'll need to create and install a secrets file, and then add a `Makefile` target specifying a few values for the new backup.
+
+### 0. Create a new secrets file
+
+Once the region global secrets have been configured, you can create a file named `rds-backup-<dbname>-secrets-<region>.yaml` using the following template:
+
+```
+apiVersion: v1
+kind: Secret
+metadata:
+  name: rds-backup-<yourdbname>
+type: Opaque
+data:
+  DBHOST: value_in_base64
+  DBNAME: value_in_base64
+  DBPASSWORD: value_in_base64
+  DBPORT: value_in_base64
+  DBUSER: value_in_base64
+  DEADMANSSNITCH_URL: value_in_base64 or empty
+```
+
+#### Secret values
+
+- `DBHOST ` - raw URL to access the DB, should NOT have a prefix (eq `pgsql://`) or a `:portnumber` suffix.
+- `DBNAME` - the name of the database to export. 
+- `DBPASSWORD` - definitely the password.
+- `DBPORT` - The port number, this is usually `5432` for Postgres or `3306` for Mysql. 
+- `DBUSER` - The db user used to connect and perform the backup.
+- `DEADMANSSNITCH_URL` - If Deadmanssnitch is being used, populate this value with the URL. Leave empty to skip this type of notification.
+
+### 1. Create the secret in Kubernetes
+
+Next, create the secret in Kubernets with the following command:
+
+```
+kubectl -n rds-backups create -f rds-backup-<dbname>-secrets-<region>.yaml
+```
+
+### 2. Add a Makefile target
+
+Once a secret has been created, you'll need to add a new target to the `Makefile` in this directory.
+
+```
+backup-frankfurt:
+    env DBTYPE=PGSQL \
+        DB_SECRETS_NAME=rds-backup-frankfurt \
+        BACKUP_POD_NAME=frankfurt \
+    ${RENDER_POD_CMD}
+
+```
+
+> Note the `\` characters at the end of each line of the make target!
+
+- `DBTYPE` - either `MYSQL` or `PGSQL`, must be in all caps or the universe will implode.
+- `DB_SECRETS_NAME` - the name of the K8s secrets resource to use. This is NOT the filename, but the value obtained from the secrets you created directly above. For example, the `DB_SECRETS_NAME` value would be `rds-backup-bedrock` if the template above was populated with:
+        
+        apiVersion: v1
+        kind: Secret
+        metadata:
+          name: rds-backup-bedrock
+        ...
+        
+- `BACKUP_POD_NAME` - the name to give the running pod. Today's date is appended as a suffix.
+
+### 3. Run the backup
+
+```
+make backup-frankfurt
+```
+
+## Troubleshooting
+
+If the backup fails to run successfully, you can start it with `DEBUG_MODE=true` to prevent the `rdsbackup.sh` script from running in the container. This
+allows you to obtain a shell in the pod for troubleshooting.
+
+```
+DEBUG_MODE=true make mdn-frankfurt
+```
+
+Connect to the pod that was started in `DEBUG_MODE` with:
+
+```
+kubectl -n rds-backups exec -it rdsbackup-frankfurt-2017-11-17 bash
+```
+
+To see a list of pods that includes pods in `Completed` status, run:
+
+```
+kubectl -n rds-backups get pods -a
+```
+
+> The main backup script in the container is called `/usr/bin/rdsbackup.sh`. 
+
+> Inspect the environment with the `env` command to see currently set values.
+
+## Decrypting a database archive
+
+You can download the backup from either the AWS web console, or the AWS cli. 
+
+```
+aws s3 cp s3://meao-rds-backups/backups/developer_mozilla_org/developer_mozilla_org.2017-11-17.sql.gz.gpg ./some_local_dir
+gpg decrypt developer_mozilla_org.2017-11-17.sql.gz.gpg | zcat | mysql ...
+```
+
+## Initial setup
+
+### S3
+
+You can use whatever S3 bucket you'd like, but these are the configuration parameters we're using:
+
+- Create an S3 bucket with logging and versioning enabled.
+    - Logging can be configured to write to `logs/`.
+- Setup a lifecycle rule to move old objects from `backups/` to Glacier.
+    - Current/previous versions of objects can be transitioned to Glacier after 30 days.
+    - Objects older than 60 days are expired from S3.
+- Create a root level directory named `backups/` in the bucket. This is to separate `logs` from lifecycle rules.
+
+### IAM 
+
+Create a user with API access the following IAM policy:
+
+```
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "s3:ListBucket"
+            ],
+            "Resource": [
+                "arn:aws:s3:::your-backup-bucket"
+            ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "s3:PutObject",
+                "s3:GetObject",
+                "s3:DeleteObject"
+            ],
+            "Resource": [
+                "arn:aws:s3:::your-backup-bucket/*"
+            ]
+        }
+    ]
+}
+```
+
+Store the access key and secret key in a safe place. You'll need it for [per-region setup](#per-region-setup).

--- a/tools/aws/rds_backup_tool/image/Dockerfile
+++ b/tools/aws/rds_backup_tool/image/Dockerfile
@@ -4,7 +4,7 @@ FROM debian:jessie-slim
 # postgresql-client fails to install in slim if this man directory doesn't exist
 # bash expansion man{1,7} doesn't work here
 RUN mkdir -p /usr/share/man/man1 && mkdir -p /usr/share/man/man7
-RUN apt update && apt -y upgrade && apt install -y curl mysql-client postgresql-client python unzip
+RUN apt update && apt -y upgrade && apt install -y curl mysql-client openssl postgresql-client python unzip
 RUN curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "awscli-bundle.zip"
 RUN unzip awscli-bundle.zip && \
      ./awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws && \

--- a/tools/aws/rds_backup_tool/image/Dockerfile
+++ b/tools/aws/rds_backup_tool/image/Dockerfile
@@ -1,0 +1,14 @@
+FROM debian:jessie-slim
+
+
+# postgresql-client fails to install in slim if this man directory doesn't exist
+# bash expansion man{1,7} doesn't work here
+RUN mkdir -p /usr/share/man/man1 && mkdir -p /usr/share/man/man7
+RUN apt update && apt -y upgrade && apt install -y curl mysql-client postgresql-client python unzip
+RUN curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "awscli-bundle.zip"
+RUN unzip awscli-bundle.zip && \
+     ./awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws && \
+     rm -rf ./awscli-bundle
+COPY ./rdsbackup.sh /usr/bin/
+RUN mkdir /backup
+CMD ["/usr/bin/rdsbackup.sh"]

--- a/tools/aws/rds_backup_tool/image/Makefile
+++ b/tools/aws/rds_backup_tool/image/Makefile
@@ -1,0 +1,5 @@
+GIT_COMMIT ?= $(shell git rev-parse HEAD)
+
+all:
+	docker build . -t quay.io/mozmar/rdsbackup:${GIT_COMMIT}
+	docker push quay.io/mozmar/rdsbackup:${GIT_COMMIT}

--- a/tools/aws/rds_backup_tool/image/rdsbackup.sh
+++ b/tools/aws/rds_backup_tool/image/rdsbackup.sh
@@ -11,7 +11,6 @@
 # BACKUP_BUCKET: where to write backup file, includes s3:// prefix
 # BACKUP_DIR: directory in the container mapped to EBS volume
 # BACKUP_PASSWORD: symmetric encryption password
-# KEEP_N_DAYS: delete files older than KEEP_N_DAYS for a particular DBNAME
 # AWS_ACCESS_KEY_ID
 # AWS_SECRET_ACCESS_KEY
 
@@ -49,15 +48,6 @@ aws_secret_access_key=${AWS_SECRET_ACCESS_KEY}
 EOF
     unset AWS_ACCESS_KEY_ID
     unset AWS_SECRET_ACCESS_KEY
-}
-
-# remove files for the current DBNAME older than KEEP_N_DAYS
-cleanup_old() {
-    echo "Cleaning up old files in ${BACKUP_OUTPUT_DIR}"
-    echo "Removing the following old local backups:"
-    find ${BACKUP_OUTPUT_DIR} -mtime +${KEEP_N_DAYS} -type f || true
-    find ${BACKUP_OUTPUT_DIR} -mtime +${KEEP_N_DAYS} -type f -delete || true
-    echo "Finished file cleanup"
 }
 
 push_to_s3() {
@@ -149,7 +139,6 @@ fi
 echo "${DBNAME} backup started at $(date)"
 check_requirements
 fix_creds
-cleanup_old
 perform_backup
 encrypt_backup
 push_to_s3

--- a/tools/aws/rds_backup_tool/image/rdsbackup.sh
+++ b/tools/aws/rds_backup_tool/image/rdsbackup.sh
@@ -123,8 +123,6 @@ notify_deadmanssnitch() {
 export MYSQL_BACKUP_OPTIONS="${BACKUP_CMD_PARAMS:- --dump-date --compress --single-transaction}"
 export PGSQL_BACKUP_OPTIONS="${BACKUP_CMD_PARAMS:- }"
 
-export KEEP_N_DAYS="${KEEP_N_DAYS:-10}"
-
 export BACKUP_OUTPUT_DIR="${BACKUP_DIR}/${DBNAME}"
 export BASE_FILENAME="${DBNAME}.$( date +%F ).sql.gz"
 export BACKUP_FILENAME="${BACKUP_OUTPUT_DIR}/${BASE_FILENAME}"

--- a/tools/aws/rds_backup_tool/image/rdsbackup.sh
+++ b/tools/aws/rds_backup_tool/image/rdsbackup.sh
@@ -1,0 +1,159 @@
+#!/bin/bash -e
+
+# env vars:
+# DBTYPE: accepts either of the following values: MYSQL or PGSQL
+# DBNAME: name of database to use in connection string
+# DBUSER: MySQL OR Postgres username
+# DBPASSWORD: MySQL OR Postgres password
+# DBHOST: MySQL OR Postgres host without port#
+# DBPORT: MySQL OR Postgres port #
+# BACKUP_CMD_PARAMS: additional parameters to pass to backup command for psql/mysql
+# BACKUP_BUCKET: where to write backup file, includes s3:// prefix
+# BACKUP_DIR: directory in the container mapped to EBS volume
+# BACKUP_PASSWORD: symmetric encryption password
+# KEEP_N_DAYS: delete files older than KEEP_N_DAYS for a particular DBNAME
+# AWS_ACCESS_KEY_ID
+# AWS_SECRET_ACCESS_KEY
+
+check_requirements() {
+    if [[ -z $DBHOST || -z $DBNAME || -z $DBPASSWORD \
+          || -z $DBPORT || -z $DBTYPE || -z $DBUSER || -z $BACKUP_DIR \
+          || -z $BACKUP_PASSWORD ]]; then
+        echo "ERROR: Not all environment variables are set."
+        echo "Minimum required vars:"
+        echo "  DBHOST"
+        echo "  DBNAME"
+        echo "  DBPASSWORD"
+        echo "  DBPORT"
+        echo "  DBTYPE"
+        echo "  DBUSER"
+        echo "  BACKUP_DIR"
+        echo "  BACKUP_PASSWORD"
+        exit 1
+    fi
+}
+
+fix_creds() {
+    # use a ~/.aws/credentials file INSTEAD of k8s set environment vars.
+    # Unset env vars after the file is written.
+    # Creds containing a slash seem to break the AWS CLI when run inside k8s,
+    # but running in docker is fine.
+    #
+    # example error:
+    # fatal error: Invalid header value b'AWS AKIAXXXX\n:ri81t84+26rX0qzRAASDDDXXXy2B70='
+    mkdir "${HOME}"/.aws
+    cat << EOF > "${HOME}"/.aws/credentials
+[default]
+aws_access_key_id=${AWS_ACCESS_KEY_ID}
+aws_secret_access_key=${AWS_SECRET_ACCESS_KEY}
+EOF
+    unset AWS_ACCESS_KEY_ID
+    unset AWS_SECRET_ACCESS_KEY
+}
+
+# remove files for the current DBNAME older than KEEP_N_DAYS
+cleanup_old() {
+    echo "Cleaning up old files in ${BACKUP_OUTPUT_DIR}"
+    echo "Removing the following old local backups:"
+    find ${BACKUP_OUTPUT_DIR} -mtime +${KEEP_N_DAYS} -type f || true
+    find ${BACKUP_OUTPUT_DIR} -mtime +${KEEP_N_DAYS} -type f -delete || true
+    echo "Finished file cleanup"
+}
+
+push_to_s3() {
+    REMOTE_DIR="${BACKUP_BUCKET}/${DBNAME}/"
+    echo "Pushing ${ENCRYPTED_BACKUP_FILENAME} to ${REMOTE_DIR}"
+    aws s3 cp "${ENCRYPTED_BACKUP_FILENAME}" "${REMOTE_DIR}"
+    echo "Finished pushing to S3"
+}
+
+encrypt_backup() {
+    echo "Encrypting ${BACKUP_FILENAME}"
+    echo -n "${BACKUP_PASSWORD}" | \
+        gpg --batch \
+            --passphrase-fd 0 \
+            --symmetric \
+            --cipher-algo aes256 \
+            ${BACKUP_FILENAME}
+    echo "Finished encrypting ${BACKUP_FILENAME}"
+    echo "Removing original: ${BACKUP_FILENAME}"
+    rm ${BACKUP_FILENAME}
+    echo "Finished encrypting"
+}
+
+postgres_backup() {
+    echo "Starting Postgresql backup on $(date)"
+    export PGUSER="${DBUSER}"
+    export PGPASSWORD="${DBPASSWORD}"
+    export PGHOST="${DBHOST}"
+    export PGPORT="${DBPORT}"
+    export PGDATABASE="${DBNAME}"
+    pg_dump "${DBNAME}" | gzip > ${BACKUP_FILENAME}
+    echo "Finished Postgresql backup on $(date)"
+}
+
+mysql_backup() {
+    echo "Starting MySQL backup on $(date)"
+    export MYSQL_PWD="${DBPASSWORD}"
+    mysqldump -u${DBUSER} \
+              -h${DBHOST} \
+              -P${DBPORT} \
+              ${MYSQL_BACKUP_OPTIONS} "${DBNAME}" | gzip > ${BACKUP_FILENAME}
+    echo "Finished MySQL backup on $(date)"
+}
+
+perform_backup() {
+    cd ${BACKUP_DIR}
+    mkdir -p ${DBNAME}
+    cd ${DBNAME}
+
+    echo "Backup output file: ${BACKUP_FILENAME}"
+    echo "Encrypted backup output file: ${ENCRYPTED_BACKUP_FILENAME}"
+
+    if [[ "${DBTYPE}" == "PGSQL" ]]; then
+        postgres_backup
+    elif [[ "${DBTYPE}" == "MYSQL" ]]; then
+        mysql_backup
+    else
+        echo "DBTYPE must be PGSQL or MYSQL"
+        exit 1
+    fi
+}
+
+notify_deadmanssnitch() {
+    if [[ -z "${DEADMANSSNITCH_URL}" ]]; then
+        echo "DEADMANSSNITCH_URL is not configured"
+    else
+        echo "updating Deadmanssnitch: ${DEADMANSSNITCH_URL}"
+        curl "${DEADMANSSNITCH_URL}"
+        echo "Deadmanssnitch updated"
+    fi
+}
+
+export MYSQL_BACKUP_OPTIONS="${BACKUP_CMD_PARAMS:- --dump-date --compress --single-transaction}"
+export PGSQL_BACKUP_OPTIONS="${BACKUP_CMD_PARAMS:- }"
+
+export KEEP_N_DAYS="${KEEP_N_DAYS:-10}"
+
+export BACKUP_OUTPUT_DIR="${BACKUP_DIR}/${DBNAME}"
+export BASE_FILENAME="${DBNAME}.$( date +%F ).sql.gz"
+export BACKUP_FILENAME="${BACKUP_OUTPUT_DIR}/${BASE_FILENAME}"
+export ENCRYPTED_BACKUP_FILENAME="${BACKUP_FILENAME}.gpg"
+
+if [ -e ${ENCRYPTED_BACKUP_FILENAME} ]
+then
+    echo "Encrypted file ${ENCRYPTED_BACKUP_FILENAME} already exists, exiting."
+    exit 1
+fi
+
+echo "${DBNAME} backup started at $(date)"
+check_requirements
+fix_creds
+cleanup_old
+perform_backup
+encrypt_backup
+push_to_s3
+notify_deadmanssnitch
+echo "${DBNAME} backup finished at $(date)"
+
+

--- a/tools/aws/rds_backup_tool/rds_backup_pod.yaml.j2
+++ b/tools/aws/rds_backup_tool/rds_backup_pod.yaml.j2
@@ -1,0 +1,68 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: rdsbackup-{{ BACKUP_POD_NAME }}-{{ BACKUP_POD_SUFFIX }}
+  namespace: {{ K8S_NAMESPACE }}
+  labels:
+    name: rdsbackup-{{ BACKUP_POD_NAME }}-{{ BACKUP_POD_SUFFIX }}
+spec:
+  restartPolicy: Never
+  containers:
+  - name: rdsbackup-{{ BACKUP_POD_NAME }}-{{ BACKUP_POD_SUFFIX }}
+    image: {{ RDS_IMAGE}}
+    {%- if DEBUG_MODE == 'true' %}
+    command: [ "/bin/bash", "-c", "--" ]
+    args: [ "while true; do sleep 30; done;" ]
+    {%- endif %}
+    env:
+      - name: DBTYPE
+        value: {{ DBTYPE }}
+      - name: BACKUP_DIR
+        value: {{ BACKUP_DIR }}
+      - name: BACKUP_BUCKET
+        value: {{ BACKUP_BUCKET }}
+      - name: AWS_ACCESS_KEY_ID
+        valueFrom:
+          secretKeyRef:
+            name: {{ BACKUP_CONFIG_SECRETS }}
+            key: AWS_ACCESS_KEY_ID
+      - name: AWS_SECRET_ACCESS_KEY
+        valueFrom:
+          secretKeyRef:
+            name: {{ BACKUP_CONFIG_SECRETS }}
+            key: AWS_SECRET_ACCESS_KEY
+      - name: BACKUP_PASSWORD
+        valueFrom:
+          secretKeyRef:
+            name: {{ BACKUP_CONFIG_SECRETS }}
+            key: BACKUP_PASSWORD
+      - name: DBHOST
+        valueFrom:
+          secretKeyRef:
+            name: {{ DB_SECRETS_NAME }}
+            key: DBHOST
+      - name: DBNAME
+        valueFrom:
+          secretKeyRef:
+            name: {{ DB_SECRETS_NAME }}
+            key: DBNAME
+      - name: DBPASSWORD
+        valueFrom:
+          secretKeyRef:
+            name: {{ DB_SECRETS_NAME }}
+            key: DBPASSWORD
+      - name: DBPORT
+        valueFrom:
+          secretKeyRef:
+            name: {{ DB_SECRETS_NAME }}
+            key: DBPORT
+      - name: DBUSER
+        valueFrom:
+          secretKeyRef:
+            name: {{ DB_SECRETS_NAME }}
+            key: DBUSER
+      - name: DEADMANSSNITCH_URL
+        valueFrom:
+          secretKeyRef:
+            name: {{ DB_SECRETS_NAME }}
+            key: DEADMANSSNITCH_URL


### PR DESCRIPTION
This PR includes a service that allows us to perform MySQL/MariaDB/Postgres RDS backups from inside a Kubernetes cluster. Please see README.md!

#### Notes:
- I skipped using an EBS volume, as it _often_ had problems detaching from completed/failed pods. This required manual intervention via the AWS console to force detach the volume. I didn't use an EBS volume during the MDN migration, so I think we'll be ok for now.
- There is no scheduling included with this PR. We can try out Jenkins cron, as we can't rely on K8s cronjobs (which aren't enabled in all of our clusters).
- this PR includes a db backup for the `frankfurt` DB. I left it in as an example of a Postgres backup.