### PR TITLE
Add ENABLE_CANDIDATE_LANGUAGES=True for stage, dev

### DIFF
--- a/apps/mdn/mdn-aws/k8s/kuma.base.yaml.j2
+++ b/apps/mdn/mdn-aws/k8s/kuma.base.yaml.j2
@@ -69,6 +69,8 @@
                 secretKeyRef:
                   name: mdn-secrets
                   key: email-url
+            - name: ENABLE_CANDIDATE_LANGUAGES
+              value: {{ KUMA_ENABLE_CANDIDATE_LANGUAGES }}
             - name: ES_INDEX_PREFIX
               value: {{ KUMA_ES_INDEX_PREFIX }}
             - name: ES_LIVE_INDEX

--- a/apps/mdn/mdn-aws/k8s/regions/frankfurt/prod.mm.sh
+++ b/apps/mdn/mdn-aws/k8s/regions/frankfurt/prod.mm.sh
@@ -113,6 +113,7 @@ export KUMA_DEBUG=False
 export KUMA_DEBUG_TOOLBAR=False
 export KUMA_DOMAIN=developer.mozilla.org
 export KUMA_EMAIL_BACKEND=django.core.mail.backends.smtp.EmailBackend
+export KUMA_ENABLE_CANDIDATE_LANGUAGES=False
 export KUMA_ES_INDEX_PREFIX=mdnprod
 export KUMA_ES_LIVE_INDEX=True
 export KUMA_LEGACY_ROOT=/mdn/www

--- a/apps/mdn/mdn-aws/k8s/regions/portland/dev.sh
+++ b/apps/mdn/mdn-aws/k8s/regions/portland/dev.sh
@@ -113,6 +113,7 @@ export KUMA_DEBUG=True
 export KUMA_DEBUG_TOOLBAR=False
 export KUMA_DOMAIN=mdn-dev.moz.works
 export KUMA_EMAIL_BACKEND=django.core.mail.backends.smtp.EmailBackend
+export KUMA_ENABLE_CANDIDATE_LANGUAGES=True
 export KUMA_ES_INDEX_PREFIX=mdn
 export KUMA_ES_LIVE_INDEX=True
 export KUMA_LEGACY_ROOT=/mdn/www

--- a/apps/mdn/mdn-aws/k8s/regions/portland/prod.mm.sh
+++ b/apps/mdn/mdn-aws/k8s/regions/portland/prod.mm.sh
@@ -114,6 +114,7 @@ export KUMA_DEBUG=False
 export KUMA_DEBUG_TOOLBAR=False
 export KUMA_DOMAIN=developer.mozilla.org
 export KUMA_EMAIL_BACKEND=django.core.mail.backends.smtp.EmailBackend
+export KUMA_ENABLE_CANDIDATE_LANGUAGES=False
 export KUMA_ES_INDEX_PREFIX=mdnprod
 export KUMA_ES_LIVE_INDEX=True
 export KUMA_LEGACY_ROOT=/mdn/www

--- a/apps/mdn/mdn-aws/k8s/regions/portland/prod.sh
+++ b/apps/mdn/mdn-aws/k8s/regions/portland/prod.sh
@@ -114,6 +114,7 @@ export KUMA_DEBUG=False
 export KUMA_DEBUG_TOOLBAR=False
 export KUMA_DOMAIN=developer.mozilla.org
 export KUMA_EMAIL_BACKEND=django.core.mail.backends.smtp.EmailBackend
+export KUMA_ENABLE_CANDIDATE_LANGUAGES=False
 export KUMA_ES_INDEX_PREFIX=mdnprod
 export KUMA_ES_LIVE_INDEX=True
 export KUMA_LEGACY_ROOT=/mdn/www

--- a/apps/mdn/mdn-aws/k8s/regions/portland/stage.mm.sh
+++ b/apps/mdn/mdn-aws/k8s/regions/portland/stage.mm.sh
@@ -114,6 +114,7 @@ export KUMA_DEBUG=False
 export KUMA_DEBUG_TOOLBAR=False
 export KUMA_DOMAIN=stage.mdn.moz.works
 export KUMA_EMAIL_BACKEND=django.core.mail.backends.smtp.EmailBackend
+export KUMA_ENABLE_CANDIDATE_LANGUAGES=True
 export KUMA_ES_INDEX_PREFIX=mdnstage
 export KUMA_ES_LIVE_INDEX=True
 export KUMA_LEGACY_ROOT=/mdn/www

--- a/apps/mdn/mdn-aws/k8s/regions/portland/stage.sh
+++ b/apps/mdn/mdn-aws/k8s/regions/portland/stage.sh
@@ -114,6 +114,7 @@ export KUMA_DEBUG=False
 export KUMA_DEBUG_TOOLBAR=False
 export KUMA_DOMAIN=stage.mdn.moz.works
 export KUMA_EMAIL_BACKEND=django.core.mail.backends.smtp.EmailBackend
+export KUMA_ENABLE_CANDIDATE_LANGUAGES=True
 export KUMA_ES_INDEX_PREFIX=mdnstage
 export KUMA_ES_LIVE_INDEX=True
 export KUMA_LEGACY_ROOT=/mdn/www


### PR DESCRIPTION
This enables candidate languages on the staging server, so that the localization team can see UI strings in context. See bug 984149.