### PR TITLE
fix boolean in kuma.base.yaml.j2 (wrap in quotes)

### DIFF
--- a/apps/mdn/mdn-aws/k8s/kuma.base.yaml.j2
+++ b/apps/mdn/mdn-aws/k8s/kuma.base.yaml.j2
@@ -70,7 +70,7 @@
                   name: mdn-secrets
                   key: email-url
             - name: ENABLE_CANDIDATE_LANGUAGES
-              value: {{ KUMA_ENABLE_CANDIDATE_LANGUAGES }}
+              value: "{{ KUMA_ENABLE_CANDIDATE_LANGUAGES }}"
             - name: ES_INDEX_PREFIX
               value: {{ KUMA_ES_INDEX_PREFIX }}
             - name: ES_LIVE_INDEX


### PR DESCRIPTION
I failed to notice that the value of the environment variable `ENABLE_CANDIDATE_LANGUAGES` in `apps/mdn/mdn-aws/k8s/kuma.base.yaml.j2` should have been wrapped in quotes.