### PR TITLE
Add Kuma env for FOUNDATION_CALLOUT

### DIFF
--- a/apps/mdn/mdn-aws/k8s/kuma.base.yaml.j2
+++ b/apps/mdn/mdn-aws/k8s/kuma.base.yaml.j2
@@ -78,6 +78,8 @@
                 secretKeyRef:
                   name: mdn-secrets
                   key: elasticsearch-url
+            - name: FOUNDATION_CALLOUT
+              value: "{{ KUMA_FOUNDATION_CALLOUT }}"
             - name: KUMASCRIPT_URL_TEMPLATE
               value: {{ KUMA_URL_TEMPLATE_FOR_KUMASCRIPT }}
             - name: LEGACY_ROOT

--- a/apps/mdn/mdn-aws/k8s/regions/frankfurt/prod.mm.sh
+++ b/apps/mdn/mdn-aws/k8s/regions/frankfurt/prod.mm.sh
@@ -115,6 +115,7 @@ export KUMA_DOMAIN=developer.mozilla.org
 export KUMA_EMAIL_BACKEND=django.core.mail.backends.smtp.EmailBackend
 export KUMA_ES_INDEX_PREFIX=mdnprod
 export KUMA_ES_LIVE_INDEX=True
+export KUMA_FOUNDATION_CALLOUT=True
 export KUMA_LEGACY_ROOT=/mdn/www
 export KUMA_MAINTENANCE_MODE=True
 export KUMA_MEDIA_ROOT=/mdn/www

--- a/apps/mdn/mdn-aws/k8s/regions/portland/dev.sh
+++ b/apps/mdn/mdn-aws/k8s/regions/portland/dev.sh
@@ -115,6 +115,7 @@ export KUMA_DOMAIN=mdn-dev.moz.works
 export KUMA_EMAIL_BACKEND=django.core.mail.backends.smtp.EmailBackend
 export KUMA_ES_INDEX_PREFIX=mdn
 export KUMA_ES_LIVE_INDEX=True
+export KUMA_FOUNDATION_CALLOUT=True
 export KUMA_LEGACY_ROOT=/mdn/www
 export KUMA_MAINTENANCE_MODE=False
 export KUMA_MEDIA_ROOT=/mdn/www

--- a/apps/mdn/mdn-aws/k8s/regions/portland/prod.mm.sh
+++ b/apps/mdn/mdn-aws/k8s/regions/portland/prod.mm.sh
@@ -116,6 +116,7 @@ export KUMA_DOMAIN=developer.mozilla.org
 export KUMA_EMAIL_BACKEND=django.core.mail.backends.smtp.EmailBackend
 export KUMA_ES_INDEX_PREFIX=mdnprod
 export KUMA_ES_LIVE_INDEX=True
+export KUMA_FOUNDATION_CALLOUT=True
 export KUMA_LEGACY_ROOT=/mdn/www
 export KUMA_MAINTENANCE_MODE=True
 export KUMA_MEDIA_ROOT=/mdn/www

--- a/apps/mdn/mdn-aws/k8s/regions/portland/prod.sh
+++ b/apps/mdn/mdn-aws/k8s/regions/portland/prod.sh
@@ -116,6 +116,7 @@ export KUMA_DOMAIN=developer.mozilla.org
 export KUMA_EMAIL_BACKEND=django.core.mail.backends.smtp.EmailBackend
 export KUMA_ES_INDEX_PREFIX=mdnprod
 export KUMA_ES_LIVE_INDEX=True
+export KUMA_FOUNDATION_CALLOUT=True
 export KUMA_LEGACY_ROOT=/mdn/www
 export KUMA_MAINTENANCE_MODE=False
 export KUMA_MEDIA_ROOT=/mdn/www

--- a/apps/mdn/mdn-aws/k8s/regions/portland/stage.mm.sh
+++ b/apps/mdn/mdn-aws/k8s/regions/portland/stage.mm.sh
@@ -116,6 +116,7 @@ export KUMA_DOMAIN=stage.mdn.moz.works
 export KUMA_EMAIL_BACKEND=django.core.mail.backends.smtp.EmailBackend
 export KUMA_ES_INDEX_PREFIX=mdnstage
 export KUMA_ES_LIVE_INDEX=True
+export KUMA_FOUNDATION_CALLOUT=True
 export KUMA_LEGACY_ROOT=/mdn/www
 export KUMA_MAINTENANCE_MODE=True
 export KUMA_MEDIA_ROOT=/mdn/www

--- a/apps/mdn/mdn-aws/k8s/regions/portland/stage.sh
+++ b/apps/mdn/mdn-aws/k8s/regions/portland/stage.sh
@@ -116,6 +116,7 @@ export KUMA_DOMAIN=stage.mdn.moz.works
 export KUMA_EMAIL_BACKEND=django.core.mail.backends.smtp.EmailBackend
 export KUMA_ES_INDEX_PREFIX=mdnstage
 export KUMA_ES_LIVE_INDEX=True
+export KUMA_FOUNDATION_CALLOUT=True
 export KUMA_LEGACY_ROOT=/mdn/www
 export KUMA_MAINTENANCE_MODE=False
 export KUMA_MEDIA_ROOT=/mdn/www


### PR DESCRIPTION
When enabled, this adds a call-to-action on the homepage to donate to the Mozilla Foundation. It goes up from late November to the first week of January. It depends on mozilla/kuma#4572 for 2017.