### PR TITLE
add infra tests for MDN ELBs

### DIFF
--- a/apps/mdn/mdn-aws/infra_testing/Makefile
+++ b/apps/mdn/mdn-aws/infra_testing/Makefile
@@ -1,0 +1,5 @@
+init:
+	pip install -r requirements.txt
+
+test:
+	pytest -s tests

--- a/apps/mdn/mdn-aws/infra_testing/README.md
+++ b/apps/mdn/mdn-aws/infra_testing/README.md
@@ -1,0 +1,14 @@
+MDN K8s infra tests
+========================
+
+```
+# install deps
+make init
+
+source ../k8s/regions/portland/stage.sh
+# or
+source ../k8s/regions/portland/prod.sh
+make test
+```
+
+> NOTE: Do NOT include test failure output in log files as it will contain sensitive information!

--- a/apps/mdn/mdn-aws/infra_testing/requirements.txt
+++ b/apps/mdn/mdn-aws/infra_testing/requirements.txt
@@ -1,0 +1,3 @@
+boto3
+kubernetes
+pytest

--- a/apps/mdn/mdn-aws/infra_testing/tests/test_listeners.py
+++ b/apps/mdn/mdn-aws/infra_testing/tests/test_listeners.py
@@ -1,0 +1,139 @@
+# -*- coding: utf-8 -*-
+
+import boto3
+from kubernetes import client, config
+import os
+import pytest
+
+# fixtures starting with k8s_ return K8s API objects
+#   documented here: https://github.com/kubernetes-incubator/client-python/blob/master/kubernetes/README.md
+# fixtures starting with aws_ return boto3 objects
+#   documented here: http://boto3.readthedocs.io/en/latest/index.html
+
+
+@pytest.fixture(scope="module")
+def k8s():
+    """A Kubernetes client"""
+    config.load_kube_config(os.environ['KUBECONFIG'])
+    return client.CoreV1Api()
+
+
+def k8s_web_service():
+    """Returns the MDN web service K8s object"""
+    services = k8s().list_namespaced_service(os.environ['K8S_NAMESPACE'])
+    web_service = [
+        elb for elb in services.items if elb.metadata.name == 'web'][0]
+    return web_service
+
+
+@pytest.fixture(scope="module")
+def k8s_web_service_elb_hostname():
+    """returns the first chunk of the elb name for the web service"""
+    elb_hostname = k8s_web_service().status.load_balancer.ingress[0].hostname
+    # an unsafe way to split the domain by . and then by -
+    return elb_hostname.split(".")[0].split("-")[0]
+
+
+@pytest.fixture(scope="module")
+def k8s_web_service_ssl_port():
+    """returns the K8s SSL port object"""
+    return [k8s_port for k8s_port in k8s_web_service().spec.ports
+            if k8s_port.port == 443][0]
+
+
+@pytest.fixture(scope="module")
+def k8s_redirector_port():
+    """returns the K8s nodeport object for the redirector service"""
+    services = k8s().list_namespaced_service('redirector')
+    redirector_service = [elb for elb in services.items
+                          if elb.metadata.name == 'redirector'][0]
+    http_port = [port for port in redirector_service.spec.ports
+                 if port.name == 'http'][0]
+    return http_port
+
+
+@pytest.fixture(scope="module")
+def aws_elb_client():
+    """returns a boto3 ELB client"""
+    return boto3.client('elb', region_name=os.environ['AWS_REGION'])
+
+
+@pytest.fixture(scope="module")
+def aws_ec2_client():
+    """returns a boto3 EC2 client"""
+    return boto3.client('ec2', region_name=os.environ['AWS_REGION'])
+
+
+@pytest.fixture(scope="module")
+def aws_elb_security_group():
+    """returns the boto3 object representing the elb_access security group"""
+    result = aws_ec2_client().describe_security_groups(
+        Filters=[{'Name': 'group-name', 'Values': ['elb_access']}])
+    return result['SecurityGroups'][0]['GroupId']
+
+
+@pytest.fixture(scope="module")
+def aws_web_service_elb_attributes():
+    """returns the boto3 object representing elb attributes for the MDN web service"""
+    response = aws_elb_client().describe_load_balancer_attributes(
+        LoadBalancerName=k8s_web_service_elb_hostname())
+    return response
+
+
+@pytest.fixture(scope="module")
+def aws_web_service_elb():
+    elb_host = k8s_web_service_elb_hostname()
+    result = aws_elb_client().describe_load_balancers(
+        LoadBalancerNames=[elb_host])
+    return result['LoadBalancerDescriptions'][0]
+
+
+class TestELB(object):
+    def test_k8s_connection(self):
+        assert k8s_web_service_elb_hostname() is not None
+
+    def test_aws_connection(self):
+        assert aws_elb_security_group() is not None
+
+    def test_elb_listeners(self):
+        elb = aws_web_service_elb()
+        # there should be http and https listeners
+        assert len(elb['ListenerDescriptions']) == 2
+        listeners = elb['ListenerDescriptions']
+
+        # get the listner using port 80
+        http = [l for l in listeners
+                if l['Listener']['LoadBalancerPort'] == 80][0]
+        assert http is not None
+        # check configured protocol
+        assert http['Listener']['Protocol'] == 'TCP'
+        # check that elb port 80 is pointing at the internal redirector service
+        # node port
+        assert http['Listener']['InstancePort'] == k8s_redirector_port().node_port
+
+        https = [l for l in listeners
+                 if l['Listener']['LoadBalancerPort'] == 443][0]
+        assert https is not None
+        # check configured protocol
+        assert https['Listener']['Protocol'] == 'HTTPS'
+        # check that elb port 443 is pointing at the internal mdn web service
+        # node port
+        assert https['Listener']['InstancePort'] == k8s_web_service_ssl_port(
+        ).node_port
+
+    def test_elb_security_group(self):
+        elb = aws_web_service_elb()
+        # is the ELB in the correct security group?
+        assert aws_elb_security_group() in elb['SecurityGroups']
+
+    def test_elb_timeout(self):
+        # is the ELB IdleTimeout set correctly?
+        elb_timeout = aws_web_service_elb_attributes(
+        )['LoadBalancerAttributes']['ConnectionSettings']['IdleTimeout']
+        assert elb_timeout == int(os.environ['WEB_GUNICORN_TIMEOUT'])
+
+    def test_elb_logging(self):
+        # is logging enabled?
+        elb_logging = aws_web_service_elb_attributes(
+        )['LoadBalancerAttributes']['AccessLog']
+        assert elb_logging['Enabled'] is True

--- a/apps/mdn/mdn-aws/infra_testing/tests/test_listeners.py
+++ b/apps/mdn/mdn-aws/infra_testing/tests/test_listeners.py
@@ -14,7 +14,7 @@ import pytest
 @pytest.fixture(scope="module")
 def k8s():
     """A Kubernetes client"""
-    config.load_kube_config(os.environ['KUBECONFIG'])
+    config.load_kube_config(os.environ.get('KUBECONFIG'))
     return client.CoreV1Api()
 
 
@@ -90,10 +90,10 @@ def aws_web_service_elb():
 
 class TestELB(object):
     def test_k8s_connection(self):
-        assert k8s_web_service_elb_hostname() is not None
+        assert k8s_web_service_elb_hostname()
 
     def test_aws_connection(self):
-        assert aws_elb_security_group() is not None
+        assert aws_elb_security_group()
 
     def test_elb_listeners(self):
         elb = aws_web_service_elb()
@@ -104,7 +104,7 @@ class TestELB(object):
         # get the listner using port 80
         http = [l for l in listeners
                 if l['Listener']['LoadBalancerPort'] == 80][0]
-        assert http is not None
+        assert http
         # check configured protocol
         assert http['Listener']['Protocol'] == 'TCP'
         # check that elb port 80 is pointing at the internal redirector service
@@ -113,7 +113,7 @@ class TestELB(object):
 
         https = [l for l in listeners
                  if l['Listener']['LoadBalancerPort'] == 443][0]
-        assert https is not None
+        assert https
         # check configured protocol
         assert https['Listener']['Protocol'] == 'HTTPS'
         # check that elb port 443 is pointing at the internal mdn web service


### PR DESCRIPTION
here's an experiment. 

This PR has some pytest code that tests stage/prod ELBs to ensure they're configured correctly, specifically:
- is the ELB configured to use port 80, and is traffic sent to the redirector NodePort?
- is the ELB configured to use port 443, and is traffic sent to the mdn web service NodePort?
- are ELB listener protocols specified correctly?
- is ELB logging enabled?
- is the connection timeout configured to use the same value as specified in the `apps/mdn/mdn-aws/k8s/Makefile`?

These tests depend on values specified in the region env files located in `apps/mdn/mdn-aws/k8s/regions/`. I'm using `os.environ` without checking for empty values: if they're empty, the test _should_ fail. Also, some boto3/k8s queries blindly access array elements, if they don't work... something is wrong with the env.

(autopep8 made my long lines ugly.)

***Do NOT run this in Jenkins or any tool that will expose build logs as failure output includes security creds etc.***