### PR TITLE
increase threshold of failure for liveness/readiness probes

### DIFF
--- a/apps/mdn/mdn-aws/k8s/kuma.deploy.yaml.j2
+++ b/apps/mdn/mdn-aws/k8s/kuma.deploy.yaml.j2
@@ -20,7 +20,9 @@
                 - name: Host
                   value: {{ KUMA_ALLOWED_HOSTS.split(',')[0].strip() }}
             initialDelaySeconds: 20
-            periodSeconds: 3
+            periodSeconds: 12
+            timeoutSeconds: 10
+            failureThreshold: 6
           readinessProbe:
             httpGet:
               path: /readiness
@@ -28,5 +30,7 @@
               httpHeaders:
                 - name: Host
                   value: {{ KUMA_ALLOWED_HOSTS.split(',')[0].strip() }}
-            initialDelaySeconds: 20
-            periodSeconds: 3
+            initialDelaySeconds: 10
+            periodSeconds: 6
+            timeoutSeconds: 5
+            failureThreshold: 3

--- a/apps/mdn/mdn-aws/k8s/kumascript.deploy.yaml.j2
+++ b/apps/mdn/mdn-aws/k8s/kumascript.deploy.yaml.j2
@@ -72,11 +72,15 @@ spec:
             httpGet:
               path: /healthz
               port: {{ KUMASCRIPT_CONTAINER_PORT }}
-            initialDelaySeconds: 10
-            periodSeconds: 3
+            initialDelaySeconds: 20
+            periodSeconds: 12
+            timeoutSeconds: 10
+            failureThreshold: 6
           readinessProbe:
             httpGet:
               path: /readiness
               port: {{ KUMASCRIPT_CONTAINER_PORT }}
             initialDelaySeconds: 10
-            periodSeconds: 3
+            periodSeconds: 6
+            timeoutSeconds: 5
+            failureThreshold: 3


### PR DESCRIPTION
After a [lengthy discussion](https://github.com/mozmeao/infra/issues/660), we decided to increase the threshold of failure for the liveness and readiness probes for both kuma and kumascript. In general, we want to be much more certain that re-routing traffic (readiness failure) or restarting (liveness failure) will lead to a successful outcome for the system.