### PR TITLE
only check CHANGE_MDN_INFRA for check-service-env target

### DIFF
--- a/apps/mdn/mdn-aws/k8s/Makefile
+++ b/apps/mdn/mdn-aws/k8s/Makefile
@@ -517,13 +517,8 @@ k8s-delete-celery-cam:
 	kubectl delete -n ${K8S_NAMESPACE} --ignore-not-found \
 		deploy ${CELERY_CAM_NAME}
 
-
-# Note that ifndef and endif are not indented to process env vars
-# before the rest of the script
 check-service-env:
-ifndef CHANGE_MDN_INFRA
-    $(error CHANGE_MDN_INFRA is undefined, set it to any value to allow infra changes)
-endif
+	./check_infra_lock.sh
 
 # These tasks don't have file targets
 .PHONY: k8s-services k8s-delete-services k8s-ns k8s-delete-ns k8s-pv-shared \

--- a/apps/mdn/mdn-aws/k8s/check_infra_lock.sh
+++ b/apps/mdn/mdn-aws/k8s/check_infra_lock.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+if [ -z ${CHANGE_MDN_INFRA+x} ]
+then
+    echo "CHANGE_MDN_INFRA is not set. Set it to any value to allow infra changes."
+    exit 1
+fi


### PR DESCRIPTION
When `CHANGE_MDN_INFRA` is not set, **all** targets fail since [this](https://github.com/mozmeao/infra/blob/c9c528919ad739d623b60b74bb898293e9ca029c/apps/mdn/mdn-aws/k8s/Makefile#L524-L526) is always run to determine what the Makefile actually "sees". I created a new bash script `check_infra_lock.sh` which is called by the `check-service-env` target, so `CHANGE_MDN_INFRA` is only checked when the target is run.