### PR TITLE
parse_log.py: Suggest the last 30 minutes of logs

### DIFF
--- a/apps/mdn/utils/parse_log.py
+++ b/apps/mdn/utils/parse_log.py
@@ -216,16 +216,25 @@ def collect_ips(log, context=None):
 
 
 def usage(name):
+    """Print usage, and suggest the last 30 minutes for logs."""
+    now = datetime.datetime.now()
+    minutes = now.minute - (now.minute % 5)
+    maxtime = datetime.datetime(now.year, now.month, now.day, now.hour, minutes)
+    mintime = maxtime - datetime.timedelta(seconds = 60 * 30)
+    fmt = '%Y-%m-%d %I:%M %p'
+    maxtime_fmt = maxtime.strftime(fmt)
+    mintime_fmt = mintime.strftime(fmt)
+    outfile = now.date().strftime('%Y-%m-%d.log')
     print("""\
 %(name)s <filename.log>: Process a papertrail log, counting IP addresses.
 
 Logs are generated using the papertrail command line app:
-papertrail --min-time '2017-11-12 4:00 AM' --max-time '2017-11-12 5:00 AM'\
+papertrail --min-time '%(mintime_fmt)s' --max-time '%(maxtime_fmt)s'\
  -g portland -- mdn-prod_web '-"GET /readiness"' '-"GET /healthz"'\
- '-"- - HTTP/1.0"' > trouble.log
+ '-"- - HTTP/1.0"' > %(outfile)s
 
 To run tests: %(name)s --test
-""")
+"""% locals())
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
In the usage for MDN's ``parse_log.py`` helper, suggest downloading the most recent 30 minutes of logs from Papertrail.