### PR TITLE
Base mdn-backup-cron image on python:3.6-slim

### DIFF
--- a/apps/mdn/utils/mdn_backup_cron/image/Dockerfile
+++ b/apps/mdn/utils/mdn_backup_cron/image/Dockerfile
@@ -1,4 +1,4 @@
-from quay.io/mozmar/base:latest
+from python:3.6-slim
 
 ENV AWS_ACCESS_KEY_ID setme
 ENV AWS_SECRET_ACCESS_KEY setme


### PR DESCRIPTION
We're moving away from ``mozmar/base``, and toward language-specific base images.

This may also help an issue where the Kuma images (using ``python:2.7-slim``) are using ``LANG=C.UTF-8``, and the ``quay.io/mozmar/base:latest`` image is leaving ``LANG`` unset and defaulting to ``LC_CTYPE=POSIX``. This may be the reason that Kuma images are creating filenames with unicode characters that the backup process can't read.