### PR TITLE
bedrock-dev elb uses 80+443 listeners to communicate with nodeport

### DIFF
--- a/elb_automation/meaoelb/elb_tool.py
+++ b/elb_automation/meaoelb/elb_tool.py
@@ -58,6 +58,20 @@ class ELBTool:
         self.all_elbs.append(service_def)
         return service_def
 
+    def define_elb_http(self, service_namespace, service_name, ssl_arn):
+        """
+        TODO
+        A convenience method for defining an ELB and storing it in 
+        a list to be created via create_elbs()
+        """
+        service_def = self.cfg_defaults.default_service_config_http(
+            service_namespace=service_namespace,
+            service_name=service_name,
+            ssl_arn=ssl_arn)
+        self.all_elbs.append(service_def)
+        return service_def
+
+
     def show_elbs(self):
         for elb in self.all_elbs:
             elb.show()

--- a/elb_automation/meaoelb/oregon_b.py
+++ b/elb_automation/meaoelb/oregon_b.py
@@ -17,6 +17,7 @@ elb_tool = ELBTool(
     vpc_id=OREGON_B_VPC,
     subnet_ids=OREGON_B_SUBNET_IDS)
 
+### Bedrock Stage
 # Define ELB's that we'd like to have created
 bedrock_stage = elb_tool.define_elb(
     service_namespace='bedrock-stage',
@@ -33,7 +34,8 @@ bedrock_stage.elb_config.elb_atts = ELBAtts(ELBAttIdleTimeout(120))
 bedrock_stage.elb_config.health_check.target_path = '/healthz/'
 
 
-bedrock_dev = elb_tool.define_elb(
+### Bedrock Dev
+bedrock_dev = elb_tool.define_elb_http(
     service_namespace='bedrock-dev',
     service_name='bedrock-nodeport',
     ssl_arn='arn:aws:acm:us-west-2:236517346949:certificate/657b1ca0-8c09-4add-90a2-1243470a6b45')


### PR DESCRIPTION
Redirector service is not used in this config