### PR TITLE
Test defined ELBs against current AWS config

### DIFF
--- a/elb_automation/meaoelb/config.py
+++ b/elb_automation/meaoelb/config.py
@@ -4,13 +4,13 @@ from pygments.lexers import JsonLexer
 from pygments.formatters import TerminalFormatter
 import re
 
+
 class DictLike(dict):
     def __getattr__(self, key):
         return self[key]
 
     def __setattr__(self, key, value):
         self[key] = value
-
 
 
 class ServiceConfig(DictLike):
@@ -32,6 +32,7 @@ class ServiceConfig(DictLike):
     def show(self):
         j = json.dumps(dict(self), indent=2, sort_keys=True)
         print(highlight(j, JsonLexer(), TerminalFormatter()))
+
 
 class ELBConfig(DictLike):
     def __init__(
@@ -60,13 +61,14 @@ class ELBConfig(DictLike):
             listeners[listener.load_balancer_port] = listener
         health_check = ELBHealthCheckConfig.from_aws(elb['HealthCheck'])
         atts = ELBAtts.from_aws(aws_atts)
-        return ELBConfig(name = elb['LoadBalancerName'],
-                         listeners = listeners, 
-                         security_groups =elb['SecurityGroups'],
-                         subnets = elb['Subnets'],
-                         tags = tags,
-                         health_check = health_check,
-                         elb_atts = atts)
+        return ELBConfig(name=elb['LoadBalancerName'],
+                         listeners=listeners,
+                         security_groups=elb['SecurityGroups'],
+                         subnets=elb['Subnets'],
+                         tags=tags,
+                         health_check=health_check,
+                         elb_atts=atts)
+
 
 class ELBAttCrossZoneLoadBalancing(DictLike):
     def __init__(self, enabled=False):
@@ -79,12 +81,13 @@ class ELBAttCrossZoneLoadBalancing(DictLike):
     def from_aws(obj):
         return ELBAttCrossZoneLoadBalancing(obj['Enabled'])
 
+
 class ELBAttAccessLog(DictLike):
     def __init__(
             self,
-            s3_bucket_name = None,
-            s3_bucket_prefix = None,
-            emit_interval = None,
+            s3_bucket_name=None,
+            s3_bucket_prefix=None,
+            emit_interval=None,
             enabled=False):
         self.enabled = enabled
         self.s3_bucket_name = s3_bucket_name
@@ -94,20 +97,20 @@ class ELBAttAccessLog(DictLike):
     def aws_merge(self, d):
         if self.enabled:
             d['AccessLog'] = {'Enabled': self.enabled,
-                            'S3BucketName': self.s3_bucket_name,
-                            'EmitInterval': self.emit_interval,
-                            'S3BucketPrefix': self.s3_bucket_prefix}
+                              'S3BucketName': self.s3_bucket_name,
+                              'EmitInterval': self.emit_interval,
+                              'S3BucketPrefix': self.s3_bucket_prefix}
         else:
             d['AccessLog'] = {'Enabled': False}
 
     @staticmethod
     def from_aws(obj):
         return ELBAttAccessLog(
-                s3_bucket_name = obj.get('S3BucketName', None),
-                s3_bucket_prefix = obj.get('S3BucketPrefix', None),
-                emit_interval = obj.get('EmitInterval', None),
-                enabled=obj['Enabled'])
-            
+            s3_bucket_name=obj.get('S3BucketName', None),
+            s3_bucket_prefix=obj.get('S3BucketPrefix', None),
+            emit_interval=obj.get('EmitInterval', None),
+            enabled=obj['Enabled'])
+
 
 class ELBAttConnectionDraining(DictLike):
     def __init__(self, timeout=300, enabled=False):
@@ -121,8 +124,9 @@ class ELBAttConnectionDraining(DictLike):
 
     @staticmethod
     def from_aws(obj):
-        return ELBAttConnectionDraining(enabled = obj['Enabled'],
-                                        timeout = obj['Timeout'])
+        return ELBAttConnectionDraining(enabled=obj['Enabled'],
+                                        timeout=obj['Timeout'])
+
 
 class ELBConnectionSettings(DictLike):
     def __init__(self, idle_timeout=120):
@@ -133,7 +137,8 @@ class ELBConnectionSettings(DictLike):
 
     @staticmethod
     def from_aws(obj):
-        return ELBConnectionSettings(idle_timeout = obj['IdleTimeout'])
+        return ELBConnectionSettings(idle_timeout=obj['IdleTimeout'])
+
 
 class ELBAtts(DictLike):
     def __init__(self):
@@ -153,11 +158,15 @@ class ELBAtts(DictLike):
     @staticmethod
     def from_aws(atts):
         newatts = ELBAtts()
-        newatts.cross_zone_load_balancing = ELBAttCrossZoneLoadBalancing.from_aws(atts['CrossZoneLoadBalancing'])
+        newatts.cross_zone_load_balancing = ELBAttCrossZoneLoadBalancing.from_aws(
+            atts['CrossZoneLoadBalancing'])
         newatts.access_log = ELBAttAccessLog.from_aws(atts['AccessLog'])
-        newatts.connection_draining = ELBAttConnectionDraining.from_aws(atts['ConnectionDraining'])
-        newatts.connection_settings = ELBConnectionSettings.from_aws(atts['ConnectionSettings'])
+        newatts.connection_draining = ELBAttConnectionDraining.from_aws(
+            atts['ConnectionDraining'])
+        newatts.connection_settings = ELBConnectionSettings.from_aws(
+            atts['ConnectionSettings'])
         return newatts
+
 
 class ELBListenerConfig(DictLike):
     def __init__(
@@ -190,11 +199,12 @@ class ELBListenerConfig(DictLike):
             cert_id = None
 
         return ELBListenerConfig(
-            protocol = listener['Protocol'],
-            load_balancer_port = int(listener['LoadBalancerPort']),
-            instance_protocol = listener['InstanceProtocol'],
-            instance_port = int(listener['InstancePort']),
-            ssl_arn = cert_id)
+            protocol=listener['Protocol'],
+            load_balancer_port=int(listener['LoadBalancerPort']),
+            instance_protocol=listener['InstanceProtocol'],
+            instance_port=int(listener['InstancePort']),
+            ssl_arn=cert_id)
+
 
 class ELBHealthCheckConfig(DictLike):
     def __init__(
@@ -220,15 +230,10 @@ class ELBHealthCheckConfig(DictLike):
         r = re.compile('([A-Z]+):([0-9]+)(\/.*)')
         matches = r.match(hc['Target'])
         return ELBHealthCheckConfig(
-                target_path = matches.group(3),
-                target_port = int(matches.group(2)),
-                target_proto = matches.group(1),
-                healthy_threshold = hc['HealthyThreshold'],
-                unhealthy_threshold = hc['UnhealthyThreshold'],
-                timeout = hc['Timeout'],
-                interval = hc['Interval'])
-
-                
-                
-                
-                
+            target_path=matches.group(3),
+            target_port=int(matches.group(2)),
+            target_proto=matches.group(1),
+            healthy_threshold=hc['HealthyThreshold'],
+            unhealthy_threshold=hc['UnhealthyThreshold'],
+            timeout=hc['Timeout'],
+            interval=hc['Interval'])

--- a/elb_automation/meaoelb/defaults.py
+++ b/elb_automation/meaoelb/defaults.py
@@ -67,6 +67,9 @@ class ELBConfigDefaults:
             ssl_arn=ssl_arn)
 
 
+    def default_elb_atts(self):
+        return ELBAtts()
+
     def default_elb_config(self,
                            service_namespace,
                            service_name,
@@ -81,7 +84,7 @@ class ELBConfigDefaults:
         redirector_listener = self.default_redirector_listener()
         service_listener = self.default_service_listener(
             service_namespace, service_name, ssl_arn)
-        listeners = [redirector_listener, service_listener]
+        listeners = {80:redirector_listener, 443:service_listener}
         health_check = self.default_health_check(
             service_namespace, service_name)
         security_groups = [self.elb_ctx.get_elb_access_security_group(vpc_id)]
@@ -89,14 +92,15 @@ class ELBConfigDefaults:
                  'Value': service_namespace},
                 {'Key': 'KubernetesCluster',
                  'Value': self.elb_ctx.get_cluster_name()}]
-
+        elb_atts = self.default_elb_atts()
         return ELBConfig(
             service_namespace,
             listeners,
             security_groups,
             subnet_ids,
             tags,
-            health_check)
+            health_check,
+            elb_atts)
 
     def default_elb_config_http(self,
                                 service_namespace,
@@ -114,7 +118,7 @@ class ELBConfigDefaults:
             service_namespace, service_name, protocol='HTTP', port=80)
         https_service_listener = self.default_service_listener(
             service_namespace, service_name, ssl_arn)
-        listeners = [http_service_listener, https_service_listener]
+        listeners = {80:http_service_listener, 443:https_service_listener}
         health_check = self.default_health_check(
             service_namespace, service_name)
         security_groups = [self.elb_ctx.get_elb_access_security_group(vpc_id)]
@@ -122,6 +126,7 @@ class ELBConfigDefaults:
                  'Value': service_namespace},
                 {'Key': 'KubernetesCluster',
                  'Value': self.elb_ctx.get_cluster_name()}]
+        elb_atts = self.default_elb_atts()
 
         return ELBConfig(
             service_namespace,
@@ -129,7 +134,8 @@ class ELBConfigDefaults:
             security_groups,
             subnet_ids,
             tags,
-            health_check)
+            health_check,
+            elb_atts)
 
 
     def generic_service_config(self,

--- a/elb_automation/meaoelb/defaults.py
+++ b/elb_automation/meaoelb/defaults.py
@@ -66,7 +66,6 @@ class ELBConfigDefaults:
             instance_port=service_nodeport,
             ssl_arn=ssl_arn)
 
-
     def default_elb_atts(self):
         return ELBAtts()
 
@@ -84,7 +83,7 @@ class ELBConfigDefaults:
         redirector_listener = self.default_redirector_listener()
         service_listener = self.default_service_listener(
             service_namespace, service_name, ssl_arn)
-        listeners = {80:redirector_listener, 443:service_listener}
+        listeners = {80: redirector_listener, 443: service_listener}
         health_check = self.default_health_check(
             service_namespace, service_name)
         security_groups = [self.elb_ctx.get_elb_access_security_group(vpc_id)]
@@ -118,7 +117,7 @@ class ELBConfigDefaults:
             service_namespace, service_name, protocol='HTTP', port=80)
         https_service_listener = self.default_service_listener(
             service_namespace, service_name, ssl_arn)
-        listeners = {80:http_service_listener, 443:https_service_listener}
+        listeners = {80: http_service_listener, 443: https_service_listener}
         health_check = self.default_health_check(
             service_namespace, service_name)
         security_groups = [self.elb_ctx.get_elb_access_security_group(vpc_id)]
@@ -136,7 +135,6 @@ class ELBConfigDefaults:
             tags,
             health_check,
             elb_atts)
-
 
     def generic_service_config(self,
                                target_cluster,
@@ -163,7 +161,6 @@ class ELBConfigDefaults:
             vpc_id=vpc_id,
             subnet_ids=subnet_ids)
 
-
     def default_service_config(self,
                                service_namespace,
                                service_name,
@@ -186,11 +183,10 @@ class ELBConfigDefaults:
             vpc_id=self.vpc_id,
             subnet_ids=self.subnet_ids)
 
-
     def default_service_config_http(self,
-                               service_namespace,
-                               service_name,
-                               ssl_arn):
+                                    service_namespace,
+                                    service_name,
+                                    ssl_arn):
         """
         Generate a service config using defaults supplied to the ConfigDefaults
         constructor. Both 80 and 443 listeners use the same K8s nodeport, the
@@ -209,4 +205,3 @@ class ELBConfigDefaults:
             elb_config=elb_config,
             vpc_id=self.vpc_id,
             subnet_ids=self.subnet_ids)
-

--- a/elb_automation/meaoelb/elb_ctx.py
+++ b/elb_automation/meaoelb/elb_ctx.py
@@ -77,7 +77,11 @@ class ELBContext:
 
     def _create_elb(self, service_config):
         elb_config = service_config.elb_config
-        print("\t➤ Creating {} ELB...".format(elb_config.name), end='', flush=True)
+        print(
+            "\t➤ Creating {} ELB...".format(
+                elb_config.name),
+            end='',
+            flush=True)
         response = self.elb_client.create_load_balancer(
             LoadBalancerName=elb_config.name,
             Listeners=list(map(lambda l: l.to_aws(), elb_config.listeners)),
@@ -122,7 +126,8 @@ class ELBContext:
         """
         if self.dry_run_mode:
             print(
-                "➤ The {} ELB would have been attached to the {} ASG:".format(service_config.elb_config.name, asg_name))
+                "➤ The {} ELB would have been attached to the {} ASG:".format(
+                    service_config.elb_config.name, asg_name))
             return
         print("\t➤ Attaching to ASG...", end='', flush=True)
         self.asg_client.attach_load_balancers(
@@ -192,13 +197,12 @@ class ELBContext:
         self.attach_elbs_to_asg(
             asg, list(map(lambda e: e.elb_config.name, services)))
 
-
     def convert_keys_to_string(self, dictionary):
         """Recursively converts dictionary keys to strings."""
         if not isinstance(dictionary, dict):
             return dictionary
-        return dict((str(k), self.convert_keys_to_string(v)) 
-            for k, v in dictionary.items())
+        return dict((str(k), self.convert_keys_to_string(v))
+                    for k, v in dictionary.items())
 
     def test_elb(self, service_config):
         """
@@ -216,7 +220,11 @@ class ELBContext:
         atts = atts_response['LoadBalancerAttributes']
         tags = tags_response['TagDescriptions'][0]['Tags']
         c = ELBConfig.from_aws(elb_def, atts, tags)
-        ddiff = DeepDiff(dict(service_config.elb_config), dict(c), ignore_order=True)
+        ddiff = DeepDiff(
+            dict(
+                service_config.elb_config),
+            dict(c),
+            ignore_order=True)
         if ddiff != {}:
             print("\t➤ ELB config has diverged:")
             print("<>" * 50)

--- a/elb_automation/meaoelb/elb_ctx.py
+++ b/elb_automation/meaoelb/elb_ctx.py
@@ -77,11 +77,7 @@ class ELBContext:
 
     def _create_elb(self, service_config):
         elb_config = service_config.elb_config
-        print(
-            "\t➤ Creating {} ELB...".format(
-                elb_config.name),
-            end='',
-            flush=True)
+        print("\t➤ Creating {} ELB...".format(elb_config.name), end='', flush=True)
         response = self.elb_client.create_load_balancer(
             LoadBalancerName=elb_config.name,
             Listeners=list(map(lambda l: l.to_aws(), elb_config.listeners)),
@@ -126,8 +122,7 @@ class ELBContext:
         """
         if self.dry_run_mode:
             print(
-                "➤ The {} ELB would have been attached to the {} ASG:".format(
-                    service_config.elb_config.name, asg_name))
+                "➤ The {} ELB would have been attached to the {} ASG:".format(service_config.elb_config.name, asg_name))
             return
         print("\t➤ Attaching to ASG...", end='', flush=True)
         self.asg_client.attach_load_balancers(
@@ -197,12 +192,13 @@ class ELBContext:
         self.attach_elbs_to_asg(
             asg, list(map(lambda e: e.elb_config.name, services)))
 
+
     def convert_keys_to_string(self, dictionary):
         """Recursively converts dictionary keys to strings."""
         if not isinstance(dictionary, dict):
             return dictionary
-        return dict((str(k), self.convert_keys_to_string(v))
-                    for k, v in dictionary.items())
+        return dict((str(k), self.convert_keys_to_string(v)) 
+            for k, v in dictionary.items())
 
     def test_elb(self, service_config):
         """
@@ -220,15 +216,11 @@ class ELBContext:
         atts = atts_response['LoadBalancerAttributes']
         tags = tags_response['TagDescriptions'][0]['Tags']
         c = ELBConfig.from_aws(elb_def, atts, tags)
-        ddiff = DeepDiff(
-            dict(
-                service_config.elb_config),
-            dict(c),
-            ignore_order=True)
+        ddiff = DeepDiff(dict(service_config.elb_config), dict(c), ignore_order=True)
         if ddiff != {}:
             print("\t➤ ELB config has diverged:")
-            print("<>" * 50)
+            print("!" * 30)
             pprint(ddiff, indent=2)
-            print("<>" * 50)
+            print("!" * 30)
         else:
             print("\t➤ ELB config is valid")

--- a/elb_automation/meaoelb/elb_ctx.py
+++ b/elb_automation/meaoelb/elb_ctx.py
@@ -212,6 +212,9 @@ class ELBContext:
         if ddiff != {}:
             print("\t➤ ELB config has diverged:")
             print("!" * 30)
+            print('- Values marked "new_value" are from AWS')
+            print('- Values marked "old_value" are from local EBS config')
+
             pprint(ddiff, indent=2)
             print("!" * 30)
         else:

--- a/elb_automation/meaoelb/elb_ctx.py
+++ b/elb_automation/meaoelb/elb_ctx.py
@@ -192,14 +192,6 @@ class ELBContext:
         self.attach_elbs_to_asg(
             asg, list(map(lambda e: e.elb_config.name, services)))
 
-
-    def convert_keys_to_string(self, dictionary):
-        """Recursively converts dictionary keys to strings."""
-        if not isinstance(dictionary, dict):
-            return dictionary
-        return dict((str(k), self.convert_keys_to_string(v)) 
-            for k, v in dictionary.items())
-
     def test_elb(self, service_config):
         """
         Compare the defined config with whats in AWS. Convert the local config

--- a/elb_automation/meaoelb/elb_ctx.py
+++ b/elb_automation/meaoelb/elb_ctx.py
@@ -213,7 +213,7 @@ class ELBContext:
             print("\t➤ ELB config has diverged:")
             print("!" * 30)
             print('- Values marked "new_value" are from AWS')
-            print('- Values marked "old_value" are from local EBS config')
+            print('- Values marked "old_value" are from local ELB config')
 
             pprint(ddiff, indent=2)
             print("!" * 30)

--- a/elb_automation/meaoelb/elb_tool.py
+++ b/elb_automation/meaoelb/elb_tool.py
@@ -58,7 +58,6 @@ class ELBTool:
 
     def define_elb_http(self, service_namespace, service_name, ssl_arn):
         """
-        TODO
         A convenience method for defining an ELB and storing it in
         a list to be created via create_elbs()
         """

--- a/elb_automation/meaoelb/elb_tool.py
+++ b/elb_automation/meaoelb/elb_tool.py
@@ -3,6 +3,7 @@ import argparse
 from meaoelb.elb_ctx import ELBContext
 from meaoelb.defaults import ELBConfigDefaults
 
+
 class ELBTool:
     def __init__(
             self,
@@ -45,7 +46,7 @@ class ELBTool:
 
     def define_elb(self, service_namespace, service_name, ssl_arn):
         """
-        A convenience method for defining an ELB and storing it in 
+        A convenience method for defining an ELB and storing it in
         a list to be created via create_elbs()
         """
         service_def = self.cfg_defaults.default_service_config(
@@ -58,7 +59,7 @@ class ELBTool:
     def define_elb_http(self, service_namespace, service_name, ssl_arn):
         """
         TODO
-        A convenience method for defining an ELB and storing it in 
+        A convenience method for defining an ELB and storing it in
         a list to be created via create_elbs()
         """
         service_def = self.cfg_defaults.default_service_config_http(
@@ -67,7 +68,6 @@ class ELBTool:
             ssl_arn=ssl_arn)
         self.all_elbs.append(service_def)
         return service_def
-
 
     def show_elbs(self):
         for elb in self.all_elbs:
@@ -79,5 +79,5 @@ class ELBTool:
         """
         print("-" * 50)
         for elb in self.all_elbs:
-            self.ctx.create_elb(service_config = elb, 
-                                asg_name = self.cfg_defaults.asg_name)
+            self.ctx.create_elb(service_config=elb,
+                                asg_name=self.cfg_defaults.asg_name)

--- a/elb_automation/meaoelb/elb_tool.py
+++ b/elb_automation/meaoelb/elb_tool.py
@@ -1,10 +1,7 @@
 import argparse
 
-
 from meaoelb.elb_ctx import ELBContext
 from meaoelb.defaults import ELBConfigDefaults
-from meaoelb.config import ELBAtts, ELBAttIdleTimeout
-
 
 class ELBTool:
     def __init__(

--- a/elb_automation/meaoelb/oregon_b.py
+++ b/elb_automation/meaoelb/oregon_b.py
@@ -16,7 +16,7 @@ elb_tool = ELBTool(
     vpc_id=OREGON_B_VPC,
     subnet_ids=OREGON_B_SUBNET_IDS)
 
-### Bedrock Stage
+# Bedrock Stage
 # Define ELB's that we'd like to have created
 bedrock_stage = elb_tool.define_elb(
     service_namespace='bedrock-stage',
@@ -44,7 +44,7 @@ bedrock_dev.elb_config.health_check.target_path = '/healthz/'
 
 # show the ELB's before we process them
 # object output is now colorized JSON
-#elb_tool.show_elbs()
+# elb_tool.show_elbs()
 
 # create and bind the ELBs
 # if an ELB has already been created, skip and continue on to the next

--- a/elb_automation/meaoelb/oregon_b.py
+++ b/elb_automation/meaoelb/oregon_b.py
@@ -1,5 +1,4 @@
 from meaoelb.elb_tool import ELBTool
-from meaoelb.config import ELBAtts, ELBAttIdleTimeout
 
 AWS_REGION = 'us-west-2'
 TARGET_CLUSTER = 'oregon-b.moz.works'
@@ -29,22 +28,24 @@ bedrock_stage = elb_tool.define_elb(
 # but elb_tool.define_elb() fills in most of the blanks for you
 
 # add an IdleTimeout as an ELB attribute
-bedrock_stage.elb_config.elb_atts = ELBAtts(ELBAttIdleTimeout(120))
+bedrock_stage.elb_config.elb_atts.connection_settings.idle_timeout = 120
 # custom health check configuration
 bedrock_stage.elb_config.health_check.target_path = '/healthz/'
 
 
-### Bedrock Dev
+# ### Bedrock Dev
 bedrock_dev = elb_tool.define_elb_http(
     service_namespace='bedrock-dev',
     service_name='bedrock-nodeport',
     ssl_arn='arn:aws:acm:us-west-2:236517346949:certificate/657b1ca0-8c09-4add-90a2-1243470a6b45')
-bedrock_dev.elb_config.elb_atts = ELBAtts(ELBAttIdleTimeout(120))
+bedrock_dev.elb_config.elb_atts.connection_settings.idle_timeout = 120
 bedrock_dev.elb_config.health_check.target_path = '/healthz/'
 
 
 # show the ELB's before we process them
-elb_tool.show_elbs()
+# object output is now colorized JSON
+#elb_tool.show_elbs()
+
 # create and bind the ELBs
 # if an ELB has already been created, skip and continue on to the next
 # This also ensures all ELBs are bound to the ASG

--- a/elb_automation/requirements.txt
+++ b/elb_automation/requirements.txt
@@ -1,2 +1,4 @@
 boto3
 kubernetes
+deepdiff
+pygments


### PR DESCRIPTION
- refactor ELB attribute classes
- set defaults for attributes based on AWS defaults
- add colorized json output for `elb_tool.show_elbs()`
  - the YAML parser doesn't seem to work with the `DictLike` class :-(
- run autopep8 on all .py files


```
$ python3 -m meaoelb.oregon_b
Dry run mode is enabled
--------------------------------------------------
➤ Processing bedrock-stage
	➤ bedrock-stage has already been provisioned
	➤ ELB config has diverged:
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
- Values marked "new_value" are from AWS
- Values marked "old_value" are from local ELB config
{ 'values_changed': { "root['listeners'][80]['instance_protocol']": { 'new_value': 'TCP',
                                                                      'old_value': 'HTTP'},
                      "root['listeners'][80]['protocol']": { 'new_value': 'TCP',
                                                             'old_value': 'HTTP'}}}
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
➤ Processing bedrock-dev
	➤ bedrock-dev has already been provisioned
	➤ ELB config is valid
```