### PR TITLE
auto generate ELB provisioning code in Python. includes Frankfurt and Tokyo

### DIFF
--- a/elb_automation/Makefile
+++ b/elb_automation/Makefile
@@ -6,3 +6,9 @@ oregon-b:
 	# actually perform the changes
 	python3 -m meaoelb.oregon_b
 
+ap-northeast-1:
+	python3 -m meaoelb.ap_northeast_1
+
+eu-central-1:
+	python3 -m meaoelb.eu_central_1
+

--- a/elb_automation/README.md
+++ b/elb_automation/README.md
@@ -71,3 +71,31 @@ elb_tool.create_and_bind_elbs()
     python3 -m meaoelb.oregon_b
     # you will still be prompted to enter "make it so" before
     # continuing
+
+---
+
+## Generate code for existing ELBs
+
+The `ELBContext` class has a `gen_region()` method on it that will
+generate 90% of the code you need to reprovision ELBs. You may wish to 
+change port numbers to K8s nodeport lookups, see `meaoelb/ap_northeast_1.py` and `meaoelb/eu_central_1.py` for example code.
+
+```
+from meaoelb.elb_ctx import ELBContext
+
+# we don't need to communicate with K8s to generate ELB code
+ctx = ELBContext(aws_region = 'eu-central-1', connect_to_k8s = False)
+ctx.gen_region()
+```
+
+Once the code is generated, you'll need to manually populate the constants at the top of the file:
+
+Example:
+
+```
+AWS_REGION = 'ap-northeast-1'
+TARGET_CLUSTER = 'tokyo.moz.works'
+ASG = "nodes.{}".format(TARGET_CLUSTER)
+VPC = 'vpc-cd1f99a9'
+SUBNET_IDS = ['subnet-115ed549', 'subnet-ed79369b']
+```

--- a/elb_automation/meaoelb/ap_northeast_1.py
+++ b/elb_automation/meaoelb/ap_northeast_1.py
@@ -1,0 +1,544 @@
+
+from meaoelb.elb_tool import ELBTool
+from meaoelb.config import *
+from meaoelb.elb_ctx import ELBContext
+
+AWS_REGION = 'ap-northeast-1'
+TARGET_CLUSTER = 'tokyo.moz.works'
+ASG = "nodes.{}".format(TARGET_CLUSTER)
+VPC = 'vpc-cd1f99a9'
+SUBNET_IDS = ['subnet-115ed549', 'subnet-ed79369b']
+
+elb_tool = ELBTool(
+    aws_region=AWS_REGION,
+    target_cluster=TARGET_CLUSTER,
+    asg_name=ASG,
+    vpc_id=VPC,
+    subnet_ids=SUBNET_IDS)
+
+redirector_port = elb_tool.ctx.get_redirector_service_nodeport()
+
+
+def define_deis_router():
+
+    http_nodeport = elb_tool.ctx.get_service_nodeport(
+        'deis', 'deis-router', 'http')
+    healthz_nodeport = elb_tool.ctx.get_service_nodeport(
+        'deis', 'deis-router', 'healthz')
+    https_nodeport = elb_tool.ctx.get_service_nodeport(
+        'deis', 'deis-router', 'https')
+    builder_nodeport = elb_tool.ctx.get_service_nodeport(
+        'deis', 'deis-router', 'builder')
+    # Health check config
+
+    hc = ELBHealthCheckConfig(target_path=None,
+                              target_port=30150,
+                              target_proto='TCP',
+                              healthy_threshold=2,
+                              unhealthy_threshold=6,
+                              timeout=5,
+                              interval=10)
+    # Listener config
+    listeners = {}
+
+    listeners[80] = \
+        ELBListenerConfig(protocol='TCP',
+                          load_balancer_port=80,
+                          instance_protocol='TCP',
+                          instance_port=30150,
+                          ssl_arn=None)
+    listeners[9090] = \
+        ELBListenerConfig(protocol='TCP',
+                          load_balancer_port=9090,
+                          instance_protocol='TCP',
+                          instance_port=31986,
+                          ssl_arn=None)
+    listeners[443] = ELBListenerConfig(
+        protocol='SSL',
+        load_balancer_port=443,
+        instance_protocol='TCP',
+        instance_port=31882,
+        ssl_arn='arn:aws:acm:ap-northeast-1:236517346949:certificate/a2a637ae-52bf-421d-bc95-6aa20eda649f')
+    listeners[2222] = \
+        ELBListenerConfig(protocol='TCP',
+                          load_balancer_port=2222,
+                          instance_protocol='TCP',
+                          instance_port=32560,
+                          ssl_arn=None)
+    # Attributes
+
+    att_czlb = ELBAttCrossZoneLoadBalancing(enabled=False)
+
+    att_access_log = ELBAttAccessLog(s3_bucket_name=None,
+                                     s3_bucket_prefix=None,
+                                     emit_interval=None,
+                                     enabled=False)
+
+    att_conn_draining = ELBAttConnectionDraining(enabled=False, timeout=300)
+
+    att_conn_settings = ELBAttConnectionSettings(idle_timeout=1200)
+    atts = ELBAtts(cross_zone_load_balancing=att_czlb,
+                   access_log=att_access_log,
+                   connection_draining=att_conn_draining,
+                   connection_settings=att_conn_settings)
+    cfg = ELBConfig(name='a63990d51037511e7845b06353bb5962',
+                    listeners=listeners,
+                    security_groups=['sg-cf763da8'],
+                    subnets=['subnet-ed79369b'],
+                    tags=[{'Key': 'kubernetes.io/service-name',
+                           'Value': 'deis/deis-router'},
+                          {'Key': 'KubernetesCluster',
+                           'Value': 'tokyo.moz.works'}],
+                    health_check=hc,
+                    elb_atts=atts)
+    return cfg
+
+
+def define_snippets():
+    nodeport = elb_tool.ctx.get_service_nodeport(
+        'snippets-prod', 'snippets-nodeport', 'https')
+
+    # Health check config
+    hc = ELBHealthCheckConfig(target_path='/healthz/',
+                              target_port=nodeport,
+                              target_proto='HTTP',
+                              healthy_threshold=2,
+                              unhealthy_threshold=6,
+                              timeout=5,
+                              interval=10)
+    # Listener config
+    listeners = {}
+
+    listeners[80] = \
+        ELBListenerConfig(protocol='TCP',
+                          load_balancer_port=80,
+                          instance_protocol='TCP',
+                          instance_port=redirector_port,
+                          ssl_arn=None)
+    listeners[443] = ELBListenerConfig(
+        protocol='SSL',
+        load_balancer_port=443,
+        instance_protocol='TCP',
+        instance_port=nodeport,
+        ssl_arn='arn:aws:iam::236517346949:server-certificate/snippets.mozilla.com')
+    # Attributes
+
+    att_czlb = ELBAttCrossZoneLoadBalancing(enabled=True)
+
+    att_access_log = ELBAttAccessLog(s3_bucket_name=None,
+                                     s3_bucket_prefix=None,
+                                     emit_interval=None,
+                                     enabled=False)
+
+    att_conn_draining = ELBAttConnectionDraining(enabled=True, timeout=300)
+
+    att_conn_settings = ELBAttConnectionSettings(idle_timeout=60)
+    atts = ELBAtts(cross_zone_load_balancing=att_czlb,
+                   access_log=att_access_log,
+                   connection_draining=att_conn_draining,
+                   connection_settings=att_conn_settings)
+    cfg = ELBConfig(name='snippets',
+                    listeners=listeners,
+                    security_groups=['sg-ac070bcb'],
+                    subnets=['subnet-ed79369b'],
+                    tags=[],
+                    health_check=hc,
+                    elb_atts=atts)
+    return cfg
+
+
+def define_careers():
+    nodeport = elb_tool.ctx.get_service_nodeport(
+        'careers-prod', 'careers-nodeport', 'https')
+
+    # Health check config
+
+    hc = ELBHealthCheckConfig(target_path='/healthz/',
+                              target_port=nodeport,
+                              target_proto='HTTP',
+                              healthy_threshold=2,
+                              unhealthy_threshold=6,
+                              timeout=5,
+                              interval=10)
+    # Listener config
+    listeners = {}
+
+    listeners[80] = \
+        ELBListenerConfig(protocol='TCP',
+                          load_balancer_port=80,
+                          instance_protocol='TCP',
+                          instance_port=redirector_port,
+                          ssl_arn=None)
+    listeners[443] = ELBListenerConfig(
+        protocol='SSL',
+        load_balancer_port=443,
+        instance_protocol='TCP',
+        instance_port=nodeport,
+        ssl_arn='arn:aws:acm:ap-northeast-1:236517346949:certificate/3a125abd-c6a2-4243-8459-3d714219ea7e')
+    # Attributes
+
+    att_czlb = ELBAttCrossZoneLoadBalancing(enabled=True)
+
+    att_access_log = ELBAttAccessLog(s3_bucket_name=None,
+                                     s3_bucket_prefix=None,
+                                     emit_interval=None,
+                                     enabled=False)
+
+    att_conn_draining = ELBAttConnectionDraining(enabled=True, timeout=300)
+
+    att_conn_settings = ELBAttConnectionSettings(idle_timeout=60)
+    atts = ELBAtts(cross_zone_load_balancing=att_czlb,
+                   access_log=att_access_log,
+                   connection_draining=att_conn_draining,
+                   connection_settings=att_conn_settings)
+    cfg = ELBConfig(name='careers',
+                    listeners=listeners,
+                    security_groups=['sg-ac070bcb'],
+                    subnets=['subnet-ed79369b'],
+                    tags=[],
+                    health_check=hc,
+                    elb_atts=atts)
+    return cfg
+
+
+def define_snippets_stats():
+    nodeport = elb_tool.ctx.get_service_nodeport(
+        'snippets-stats', 'snippets-stats-nodeport', 'https')
+
+    # Health check config
+
+    hc = ELBHealthCheckConfig(target_path='/',
+                              target_port=nodeport,
+                              target_proto='HTTP',
+                              healthy_threshold=2,
+                              unhealthy_threshold=6,
+                              timeout=5,
+                              interval=10)
+    # Listener config
+    listeners = {}
+
+    listeners[80] = \
+        ELBListenerConfig(protocol='TCP',
+                          load_balancer_port=80,
+                          instance_protocol='TCP',
+                          instance_port=redirector_port,
+                          ssl_arn=None)
+    listeners[443] = ELBListenerConfig(
+        protocol='SSL',
+        load_balancer_port=443,
+        instance_protocol='TCP',
+        instance_port=nodeport,
+        ssl_arn='arn:aws:acm:ap-northeast-1:236517346949:certificate/3fd8337d-9476-46a9-acda-47abc3b95472')
+    # Attributes
+
+    att_czlb = ELBAttCrossZoneLoadBalancing(enabled=True)
+
+    att_access_log = ELBAttAccessLog(s3_bucket_name=None,
+                                     s3_bucket_prefix=None,
+                                     emit_interval=None,
+                                     enabled=False)
+
+    att_conn_draining = ELBAttConnectionDraining(enabled=True, timeout=300)
+
+    att_conn_settings = ELBAttConnectionSettings(idle_timeout=60)
+    atts = ELBAtts(cross_zone_load_balancing=att_czlb,
+                   access_log=att_access_log,
+                   connection_draining=att_conn_draining,
+                   connection_settings=att_conn_settings)
+    cfg = ELBConfig(name='snippets-stats',
+                    listeners=listeners,
+                    security_groups=['sg-ac070bcb'],
+                    subnets=['subnet-ed79369b'],
+                    tags=[],
+                    health_check=hc,
+                    elb_atts=atts)
+    return cfg
+
+
+def define_mdn_dev():
+    # TODO: DECOM this, it's probably unused!
+
+    # Health check config
+
+    hc = ELBHealthCheckConfig(target_path=None,
+                              target_port=30420,
+                              target_proto='TCP',
+                              healthy_threshold=2,
+                              unhealthy_threshold=6,
+                              timeout=5,
+                              interval=10)
+    # Listener config
+    listeners = {}
+
+    listeners[80] = \
+        ELBListenerConfig(protocol='TCP',
+                          load_balancer_port=80,
+                          instance_protocol='TCP',
+                          instance_port=30420,
+                          ssl_arn=None)
+    # Attributes
+
+    att_czlb = ELBAttCrossZoneLoadBalancing(enabled=False)
+
+    att_access_log = ELBAttAccessLog(s3_bucket_name=None,
+                                     s3_bucket_prefix=None,
+                                     emit_interval=None,
+                                     enabled=False)
+
+    att_conn_draining = ELBAttConnectionDraining(enabled=False, timeout=300)
+
+    att_conn_settings = ELBAttConnectionSettings(idle_timeout=60)
+    atts = ELBAtts(cross_zone_load_balancing=att_czlb,
+                   access_log=att_access_log,
+                   connection_draining=att_conn_draining,
+                   connection_settings=att_conn_settings)
+    cfg = ELBConfig(name='a09c0082826ea11e7845b06353bb5962',
+                    listeners=listeners,
+                    security_groups=['sg-2bbcaa4c'],
+                    subnets=['subnet-ed79369b'],
+                    tags=[{'Key': 'kubernetes.io/service-name',
+                           'Value': 'mdn-dev/web'},
+                          {'Key': 'KubernetesCluster',
+                           'Value': 'tokyo.moz.works'}],
+                    health_check=hc,
+                    elb_atts=atts)
+    return cfg
+
+
+def define_bedrock_stage():
+    nodeport = elb_tool.ctx.get_service_nodeport(
+        'bedrock-stage', 'bedrock-nodeport', 'https')
+
+    # Health check config
+
+    hc = ELBHealthCheckConfig(target_path='/healthz/',
+                              target_port=nodeport,
+                              target_proto='HTTP',
+                              healthy_threshold=2,
+                              unhealthy_threshold=6,
+                              timeout=5,
+                              interval=10)
+    # Listener config
+    listeners = {}
+
+    listeners[80] = \
+        ELBListenerConfig(protocol='HTTP',
+                          load_balancer_port=80,
+                          instance_protocol='HTTP',
+                          instance_port=redirector_port,
+                          ssl_arn=None)
+    listeners[443] = ELBListenerConfig(
+        protocol='HTTPS',
+        load_balancer_port=443,
+        instance_protocol='HTTP',
+        instance_port=nodeport,
+        ssl_arn='arn:aws:iam::236517346949:server-certificate/wildcard.allizom.org_20180103')
+    # Attributes
+
+    att_czlb = ELBAttCrossZoneLoadBalancing(enabled=True)
+
+    att_access_log = ELBAttAccessLog(s3_bucket_name=None,
+                                     s3_bucket_prefix=None,
+                                     emit_interval=None,
+                                     enabled=False)
+
+    att_conn_draining = ELBAttConnectionDraining(enabled=True, timeout=300)
+
+    att_conn_settings = ELBAttConnectionSettings(idle_timeout=60)
+    atts = ELBAtts(cross_zone_load_balancing=att_czlb,
+                   access_log=att_access_log,
+                   connection_draining=att_conn_draining,
+                   connection_settings=att_conn_settings)
+    cfg = ELBConfig(name='bedrock-stage',
+                    listeners=listeners,
+                    security_groups=['sg-ac070bcb'],
+                    subnets=['subnet-ed79369b'],
+                    tags=[],
+                    health_check=hc,
+                    elb_atts=atts)
+    return cfg
+
+
+def define_bedrock_prod():
+    nodeport = elb_tool.ctx.get_service_nodeport(
+        'bedrock-prod', 'bedrock-nodeport', 'https')
+
+    # Health check config
+
+    hc = ELBHealthCheckConfig(target_path='/healthz/',
+                              target_port=nodeport,
+                              target_proto='HTTP',
+                              healthy_threshold=2,
+                              unhealthy_threshold=6,
+                              timeout=5,
+                              interval=10)
+    # Listener config
+    listeners = {}
+
+    listeners[80] = \
+        ELBListenerConfig(protocol='HTTP',
+                          load_balancer_port=80,
+                          instance_protocol='HTTP',
+                          instance_port=redirector_port,
+                          ssl_arn=None)
+    listeners[443] = ELBListenerConfig(
+        protocol='HTTPS',
+        load_balancer_port=443,
+        instance_protocol='HTTP',
+        instance_port=nodeport,
+        ssl_arn='arn:aws:acm:ap-northeast-1:236517346949:certificate/099d5838-a413-478a-abc1-afb67c4017f1')
+    # Attributes
+
+    att_czlb = ELBAttCrossZoneLoadBalancing(enabled=True)
+
+    att_access_log = ELBAttAccessLog(s3_bucket_name=None,
+                                     s3_bucket_prefix=None,
+                                     emit_interval=None,
+                                     enabled=False)
+
+    att_conn_draining = ELBAttConnectionDraining(enabled=True, timeout=300)
+
+    att_conn_settings = ELBAttConnectionSettings(idle_timeout=60)
+    atts = ELBAtts(cross_zone_load_balancing=att_czlb,
+                   access_log=att_access_log,
+                   connection_draining=att_conn_draining,
+                   connection_settings=att_conn_settings)
+    cfg = ELBConfig(name='bedrock-prod',
+                    listeners=listeners,
+                    security_groups=['sg-ac070bcb'],
+                    subnets=['subnet-ed79369b'],
+                    tags=[],
+                    health_check=hc,
+                    elb_atts=atts)
+    return cfg
+
+
+def define_basket_stage():
+    nodeport = elb_tool.ctx.get_service_nodeport(
+        'basket-stage', 'basket-nodeport', 'http')
+    # Health check config
+
+    hc = ELBHealthCheckConfig(target_path='/healthz/',
+                              target_port=nodeport,
+                              target_proto='HTTP',
+                              healthy_threshold=2,
+                              unhealthy_threshold=6,
+                              timeout=5,
+                              interval=10)
+    # Listener config
+    listeners = {}
+
+    listeners[80] = \
+        ELBListenerConfig(protocol='TCP',
+                          load_balancer_port=80,
+                          instance_protocol='TCP',
+                          instance_port=redirector_port,
+                          ssl_arn=None)
+    listeners[443] = ELBListenerConfig(
+        protocol='SSL',
+        load_balancer_port=443,
+        instance_protocol='TCP',
+        instance_port=nodeport,
+        ssl_arn='arn:aws:acm:ap-northeast-1:236517346949:certificate/f2f3eb0a-c9c9-4404-b89d-16d3e47b8bcc')
+    # Attributes
+
+    att_czlb = ELBAttCrossZoneLoadBalancing(enabled=True)
+
+    att_access_log = ELBAttAccessLog(s3_bucket_name=None,
+                                     s3_bucket_prefix=None,
+                                     emit_interval=None,
+                                     enabled=False)
+
+    att_conn_draining = ELBAttConnectionDraining(enabled=True, timeout=300)
+
+    att_conn_settings = ELBAttConnectionSettings(idle_timeout=60)
+    atts = ELBAtts(cross_zone_load_balancing=att_czlb,
+                   access_log=att_access_log,
+                   connection_draining=att_conn_draining,
+                   connection_settings=att_conn_settings)
+    cfg = ELBConfig(name='basket-stage',
+                    listeners=listeners,
+                    security_groups=['sg-ac070bcb'],
+                    subnets=['subnet-ed79369b'],
+                    tags=[],
+                    health_check=hc,
+                    elb_atts=atts)
+    return cfg
+
+
+def define_basket_prod():
+    nodeport = elb_tool.ctx.get_service_nodeport(
+        'basket-prod', 'basket-nodeport', 'http')
+
+    # Health check config
+
+    hc = ELBHealthCheckConfig(target_path='/healthz/',
+                              target_port=nodeport,
+                              target_proto='HTTP',
+                              healthy_threshold=2,
+                              unhealthy_threshold=6,
+                              timeout=5,
+                              interval=10)
+    # Listener config
+    listeners = {}
+
+    listeners[80] = \
+        ELBListenerConfig(protocol='TCP',
+                          load_balancer_port=80,
+                          instance_protocol='TCP',
+                          instance_port=redirector_port,
+                          ssl_arn=None)
+    listeners[443] = ELBListenerConfig(
+        protocol='SSL',
+        load_balancer_port=443,
+        instance_protocol='TCP',
+        instance_port=nodeport,
+        ssl_arn='arn:aws:acm:ap-northeast-1:236517346949:certificate/9c13521f-c93e-42f0-b969-b11fd571ff91')
+    # Attributes
+
+    att_czlb = ELBAttCrossZoneLoadBalancing(enabled=True)
+
+    att_access_log = ELBAttAccessLog(s3_bucket_name=None,
+                                     s3_bucket_prefix=None,
+                                     emit_interval=None,
+                                     enabled=False)
+
+    att_conn_draining = ELBAttConnectionDraining(enabled=True, timeout=300)
+
+    att_conn_settings = ELBAttConnectionSettings(idle_timeout=60)
+    atts = ELBAtts(cross_zone_load_balancing=att_czlb,
+                   access_log=att_access_log,
+                   connection_draining=att_conn_draining,
+                   connection_settings=att_conn_settings)
+    cfg = ELBConfig(name='basket-prod',
+                    listeners=listeners,
+                    security_groups=['sg-ac070bcb'],
+                    subnets=['subnet-ed79369b'],
+                    tags=[],
+                    health_check=hc,
+                    elb_atts=atts)
+    return cfg
+
+
+elb_tool.define_generic_elb(define_deis_router())
+elb_tool.define_generic_elb(define_snippets())
+elb_tool.define_generic_elb(define_careers())
+elb_tool.define_generic_elb(define_snippets_stats())
+elb_tool.define_generic_elb(define_mdn_dev())
+elb_tool.define_generic_elb(define_bedrock_stage())
+elb_tool.define_generic_elb(define_bedrock_prod())
+elb_tool.define_generic_elb(define_basket_stage())
+elb_tool.define_generic_elb(define_basket_prod())
+
+
+# TODO: to automatically assign instance ports to K8s nodeports, replace
+# target_port=30150,
+#   with
+# target_port = elb_tool.ctx.get_service_nodeport(service_namespace, service_name),
+#    OR
+# target_port = elb_tool.ctx.get_service_nodeport(service_namespace, service_name, "my_nodeport_name"),
+
+# TODO: to use the redirector service nodeport:
+# target_port = redirector_port
+
+elb_tool.test_elbs()

--- a/elb_automation/meaoelb/eu_central_1.py
+++ b/elb_automation/meaoelb/eu_central_1.py
@@ -1,0 +1,652 @@
+
+from meaoelb.elb_tool import ELBTool
+from meaoelb.config import *
+from meaoelb.elb_ctx import ELBContext
+
+AWS_REGION = 'eu-central-1'
+TARGET_CLUSTER = 'frankfurt.moz.works'
+ASG = "nodes.{}".format(TARGET_CLUSTER)
+VPC = 'vpc-4d036a25'
+SUBNET_IDS = ['subnet-10685f78', 'subnet-57ef9f2d']
+
+elb_tool = ELBTool(
+    aws_region=AWS_REGION,
+    target_cluster=TARGET_CLUSTER,
+    asg_name=ASG,
+    vpc_id=VPC,
+    subnet_ids=SUBNET_IDS)
+
+redirector_port = elb_tool.ctx.get_redirector_service_nodeport()
+
+
+def define_deis_router():
+    http_nodeport = elb_tool.ctx.get_service_nodeport(
+        'deis', 'deis-router', 'http')
+    healthz_nodeport = elb_tool.ctx.get_service_nodeport(
+        'deis', 'deis-router', 'healthz')
+    https_nodeport = elb_tool.ctx.get_service_nodeport(
+        'deis', 'deis-router', 'https')
+    builder_nodeport = elb_tool.ctx.get_service_nodeport(
+        'deis', 'deis-router', 'builder')
+
+    # Health check config
+
+    hc = ELBHealthCheckConfig(target_path=None,
+                              target_port=http_nodeport,
+                              target_proto='TCP',
+                              healthy_threshold=2,
+                              unhealthy_threshold=6,
+                              timeout=5,
+                              interval=10)
+    # Listener config
+    listeners = {}
+
+    listeners[80] = \
+        ELBListenerConfig(protocol='TCP',
+                          load_balancer_port=80,
+                          instance_protocol='TCP',
+                          instance_port=http_nodeport,
+                          ssl_arn=None)
+    listeners[9090] = \
+        ELBListenerConfig(protocol='TCP',
+                          load_balancer_port=9090,
+                          instance_protocol='TCP',
+                          instance_port=healthz_nodeport,
+                          ssl_arn=None)
+    listeners[443] = ELBListenerConfig(
+        protocol='SSL',
+        load_balancer_port=443,
+        instance_protocol='TCP',
+        instance_port=https_nodeport,
+        ssl_arn='arn:aws:acm:eu-central-1:236517346949:certificate/b36619b5-599a-44df-91c9-6063c6e1c238')
+    listeners[2222] = \
+        ELBListenerConfig(protocol='TCP',
+                          load_balancer_port=2222,
+                          instance_protocol='TCP',
+                          instance_port=builder_nodeport,
+                          ssl_arn=None)
+    # Attributes
+
+    att_czlb = ELBAttCrossZoneLoadBalancing(enabled=False)
+
+    att_access_log = ELBAttAccessLog(s3_bucket_name=None,
+                                     s3_bucket_prefix=None,
+                                     emit_interval=None,
+                                     enabled=False)
+
+    att_conn_draining = ELBAttConnectionDraining(enabled=False, timeout=300)
+
+    att_conn_settings = ELBAttConnectionSettings(idle_timeout=1200)
+    atts = ELBAtts(cross_zone_load_balancing=att_czlb,
+                   access_log=att_access_log,
+                   connection_draining=att_conn_draining,
+                   connection_settings=att_conn_settings)
+    cfg = ELBConfig(name='a82511f724fb611e78dc902859405480',
+                    listeners=listeners,
+                    security_groups=['sg-8d1064e6'],
+                    subnets=['subnet-10685f78'],
+                    tags=[{'Key': 'kubernetes.io/service-name',
+                           'Value': 'deis/deis-router'},
+                          {'Key': 'KubernetesCluster',
+                           'Value': 'frankfurt.moz.works'},
+                          {'Key': 'kubernetes.io/cluster/frankfurt.moz.works',
+                           'Value': 'owned'}],
+                    health_check=hc,
+                    elb_atts=atts)
+    return cfg
+
+
+def define_basket_prod():
+    nodeport = elb_tool.ctx.get_service_nodeport(
+        'basket-prod', 'basket-nodeport', 'http')
+
+    # Health check config
+
+    hc = ELBHealthCheckConfig(target_path='/healthz/',
+                              target_port=nodeport,
+                              target_proto='HTTP',
+                              healthy_threshold=2,
+                              unhealthy_threshold=6,
+                              timeout=5,
+                              interval=10)
+    # Listener config
+    listeners = {}
+
+    listeners[80] = \
+        ELBListenerConfig(protocol='TCP',
+                          load_balancer_port=80,
+                          instance_protocol='TCP',
+                          instance_port=redirector_port,
+                          ssl_arn=None)
+    listeners[443] = ELBListenerConfig(
+        protocol='SSL',
+        load_balancer_port=443,
+        instance_protocol='TCP',
+        instance_port=nodeport,
+        ssl_arn='arn:aws:acm:eu-central-1:236517346949:certificate/eac03015-d53b-42f2-84e9-2b58a0231e8b')
+    # Attributes
+
+    att_czlb = ELBAttCrossZoneLoadBalancing(enabled=True)
+
+    att_access_log = ELBAttAccessLog(s3_bucket_name=None,
+                                     s3_bucket_prefix=None,
+                                     emit_interval=None,
+                                     enabled=False)
+
+    att_conn_draining = ELBAttConnectionDraining(enabled=True, timeout=300)
+
+    att_conn_settings = ELBAttConnectionSettings(idle_timeout=60)
+    atts = ELBAtts(cross_zone_load_balancing=att_czlb,
+                   access_log=att_access_log,
+                   connection_draining=att_conn_draining,
+                   connection_settings=att_conn_settings)
+    cfg = ELBConfig(name='basket-prod',
+                    listeners=listeners,
+                    security_groups=['sg-02552a69'],
+                    subnets=['subnet-10685f78'],
+                    tags=[],
+                    health_check=hc,
+                    elb_atts=atts)
+    return cfg
+
+
+def define_basket_stage():
+    nodeport = elb_tool.ctx.get_service_nodeport(
+        'basket-stage', 'basket-nodeport', 'http')
+
+    # Health check config
+
+    hc = ELBHealthCheckConfig(target_path='/healthz/',
+                              target_port=nodeport,
+                              target_proto='HTTP',
+                              healthy_threshold=2,
+                              unhealthy_threshold=6,
+                              timeout=5,
+                              interval=10)
+    # Listener config
+    listeners = {}
+
+    listeners[80] = \
+        ELBListenerConfig(protocol='TCP',
+                          load_balancer_port=80,
+                          instance_protocol='TCP',
+                          instance_port=redirector_port,
+                          ssl_arn=None)
+    listeners[443] = ELBListenerConfig(
+        protocol='SSL',
+        load_balancer_port=443,
+        instance_protocol='TCP',
+        instance_port=nodeport,
+        ssl_arn='arn:aws:acm:eu-central-1:236517346949:certificate/fa2169bd-cd78-4024-adf2-659424de6b45')
+    # Attributes
+
+    att_czlb = ELBAttCrossZoneLoadBalancing(enabled=True)
+
+    att_access_log = ELBAttAccessLog(s3_bucket_name=None,
+                                     s3_bucket_prefix=None,
+                                     emit_interval=None,
+                                     enabled=False)
+
+    att_conn_draining = ELBAttConnectionDraining(enabled=True, timeout=300)
+
+    att_conn_settings = ELBAttConnectionSettings(idle_timeout=60)
+    atts = ELBAtts(cross_zone_load_balancing=att_czlb,
+                   access_log=att_access_log,
+                   connection_draining=att_conn_draining,
+                   connection_settings=att_conn_settings)
+    cfg = ELBConfig(name='basket-stage',
+                    listeners=listeners,
+                    security_groups=['sg-02552a69'],
+                    subnets=['subnet-10685f78'],
+                    tags=[],
+                    health_check=hc,
+                    elb_atts=atts)
+    return cfg
+
+
+def define_snippets():
+    nodeport = elb_tool.ctx.get_service_nodeport(
+        'snippets-prod', 'snippets-nodeport', 'https')
+    # Health check config
+
+    hc = ELBHealthCheckConfig(target_path='/healthz/',
+                              target_port=nodeport,
+                              target_proto='HTTP',
+                              healthy_threshold=2,
+                              unhealthy_threshold=6,
+                              timeout=5,
+                              interval=10)
+    # Listener config
+    listeners = {}
+
+    listeners[80] = \
+        ELBListenerConfig(protocol='TCP',
+                          load_balancer_port=80,
+                          instance_protocol='TCP',
+                          instance_port=redirector_port,
+                          ssl_arn=None)
+    listeners[443] = ELBListenerConfig(
+        protocol='SSL',
+        load_balancer_port=443,
+        instance_protocol='TCP',
+        instance_port=nodeport,
+        ssl_arn='arn:aws:iam::236517346949:server-certificate/snippets.mozilla.com')
+    # Attributes
+
+    att_czlb = ELBAttCrossZoneLoadBalancing(enabled=True)
+
+    att_access_log = ELBAttAccessLog(s3_bucket_name=None,
+                                     s3_bucket_prefix=None,
+                                     emit_interval=None,
+                                     enabled=False)
+
+    att_conn_draining = ELBAttConnectionDraining(enabled=True, timeout=300)
+
+    att_conn_settings = ELBAttConnectionSettings(idle_timeout=60)
+    atts = ELBAtts(cross_zone_load_balancing=att_czlb,
+                   access_log=att_access_log,
+                   connection_draining=att_conn_draining,
+                   connection_settings=att_conn_settings)
+    cfg = ELBConfig(name='snippets',
+                    listeners=listeners,
+                    security_groups=['sg-02552a69'],
+                    subnets=['subnet-10685f78'],
+                    tags=[],
+                    health_check=hc,
+                    elb_atts=atts)
+    return cfg
+
+
+def define_careers():
+    nodeport = elb_tool.ctx.get_service_nodeport(
+        'careers-prod', 'careers-nodeport', 'https')
+
+    # Health check config
+
+    hc = ELBHealthCheckConfig(target_path='/healthz/',
+                              target_port=nodeport,
+                              target_proto='HTTP',
+                              healthy_threshold=2,
+                              unhealthy_threshold=6,
+                              timeout=5,
+                              interval=10)
+    # Listener config
+    listeners = {}
+
+    listeners[80] = \
+        ELBListenerConfig(protocol='TCP',
+                          load_balancer_port=80,
+                          instance_protocol='TCP',
+                          instance_port=redirector_port,
+                          ssl_arn=None)
+    listeners[443] = ELBListenerConfig(
+        protocol='SSL',
+        load_balancer_port=443,
+        instance_protocol='TCP',
+        instance_port=nodeport,
+        ssl_arn='arn:aws:acm:eu-central-1:236517346949:certificate/c92264e0-d477-417e-ab3b-fc15c65a574e')
+    # Attributes
+
+    att_czlb = ELBAttCrossZoneLoadBalancing(enabled=True)
+
+    att_access_log = ELBAttAccessLog(s3_bucket_name=None,
+                                     s3_bucket_prefix=None,
+                                     emit_interval=None,
+                                     enabled=False)
+
+    att_conn_draining = ELBAttConnectionDraining(enabled=True, timeout=300)
+
+    att_conn_settings = ELBAttConnectionSettings(idle_timeout=60)
+    atts = ELBAtts(cross_zone_load_balancing=att_czlb,
+                   access_log=att_access_log,
+                   connection_draining=att_conn_draining,
+                   connection_settings=att_conn_settings)
+    cfg = ELBConfig(name='careers',
+                    listeners=listeners,
+                    security_groups=['sg-02552a69'],
+                    subnets=['subnet-10685f78'],
+                    tags=[],
+                    health_check=hc,
+                    elb_atts=atts)
+    return cfg
+
+
+def define_bedrock_prod():
+    nodeport = elb_tool.ctx.get_service_nodeport(
+        'bedrock-prod', 'bedrock-nodeport', 'https')
+
+    # Health check config
+
+    hc = ELBHealthCheckConfig(target_path='/healthz/',
+                              target_port=nodeport,
+                              target_proto='HTTP',
+                              healthy_threshold=2,
+                              unhealthy_threshold=6,
+                              timeout=5,
+                              interval=10)
+    # Listener config
+    listeners = {}
+
+    listeners[80] = \
+        ELBListenerConfig(protocol='HTTP',
+                          load_balancer_port=80,
+                          instance_protocol='HTTP',
+                          instance_port=redirector_port,
+                          ssl_arn=None)
+    listeners[443] = ELBListenerConfig(
+        protocol='HTTPS',
+        load_balancer_port=443,
+        instance_protocol='HTTP',
+        instance_port=nodeport,
+        ssl_arn='arn:aws:acm:eu-central-1:236517346949:certificate/640c6dd9-55e7-4b29-9c82-35f0a630b3f9')
+    # Attributes
+
+    att_czlb = ELBAttCrossZoneLoadBalancing(enabled=True)
+
+    att_access_log = ELBAttAccessLog(s3_bucket_name=None,
+                                     s3_bucket_prefix=None,
+                                     emit_interval=None,
+                                     enabled=False)
+
+    att_conn_draining = ELBAttConnectionDraining(enabled=True, timeout=300)
+
+    att_conn_settings = ELBAttConnectionSettings(idle_timeout=60)
+    atts = ELBAtts(cross_zone_load_balancing=att_czlb,
+                   access_log=att_access_log,
+                   connection_draining=att_conn_draining,
+                   connection_settings=att_conn_settings)
+    cfg = ELBConfig(name='bedrock-prod',
+                    listeners=listeners,
+                    security_groups=['sg-02552a69'],
+                    subnets=['subnet-10685f78'],
+                    tags=[],
+                    health_check=hc,
+                    elb_atts=atts)
+    return cfg
+
+
+def define_bedrock_stage():
+    nodeport = elb_tool.ctx.get_service_nodeport(
+        'bedrock-stage', 'bedrock-nodeport', 'https')
+    # Health check config
+
+    hc = ELBHealthCheckConfig(target_path='/healthz/',
+                              target_port=nodeport,
+                              target_proto='HTTP',
+                              healthy_threshold=2,
+                              unhealthy_threshold=6,
+                              timeout=5,
+                              interval=10)
+    # Listener config
+    listeners = {}
+
+    listeners[80] = \
+        ELBListenerConfig(protocol='HTTP',
+                          load_balancer_port=80,
+                          instance_protocol='HTTP',
+                          instance_port=redirector_port,
+                          ssl_arn=None)
+    listeners[443] = ELBListenerConfig(
+        protocol='HTTPS',
+        load_balancer_port=443,
+        instance_protocol='HTTP',
+        instance_port=nodeport,
+        ssl_arn='arn:aws:acm:eu-central-1:236517346949:certificate/bd00d1ef-57a9-4e65-8bff-7db5c95d477d')
+    # Attributes
+
+    att_czlb = ELBAttCrossZoneLoadBalancing(enabled=True)
+
+    att_access_log = ELBAttAccessLog(s3_bucket_name=None,
+                                     s3_bucket_prefix=None,
+                                     emit_interval=None,
+                                     enabled=False)
+
+    att_conn_draining = ELBAttConnectionDraining(enabled=True, timeout=300)
+
+    att_conn_settings = ELBAttConnectionSettings(idle_timeout=60)
+    atts = ELBAtts(cross_zone_load_balancing=att_czlb,
+                   access_log=att_access_log,
+                   connection_draining=att_conn_draining,
+                   connection_settings=att_conn_settings)
+    cfg = ELBConfig(name='bedrock-stage',
+                    listeners=listeners,
+                    security_groups=['sg-02552a69'],
+                    subnets=['subnet-10685f78'],
+                    tags=[],
+                    health_check=hc,
+                    elb_atts=atts)
+    return cfg
+
+
+def define_snippets_stats():
+    nodeport = elb_tool.ctx.get_service_nodeport(
+        'snippets-stats', 'snippets-stats-nodeport', 'https')
+    # Health check config
+
+    hc = ELBHealthCheckConfig(target_path='/',
+                              target_port=nodeport,
+                              target_proto='HTTP',
+                              healthy_threshold=2,
+                              unhealthy_threshold=6,
+                              timeout=5,
+                              interval=10)
+    # Listener config
+    listeners = {}
+
+    listeners[80] = \
+        ELBListenerConfig(protocol='TCP',
+                          load_balancer_port=80,
+                          instance_protocol='TCP',
+                          instance_port=redirector_port,
+                          ssl_arn=None)
+    listeners[443] = ELBListenerConfig(
+        protocol='SSL',
+        load_balancer_port=443,
+        instance_protocol='TCP',
+        instance_port=nodeport,
+        ssl_arn='arn:aws:acm:eu-central-1:236517346949:certificate/290a91d7-4f69-4791-b670-534b671bd6b8')
+    # Attributes
+
+    att_czlb = ELBAttCrossZoneLoadBalancing(enabled=True)
+
+    att_access_log = ELBAttAccessLog(s3_bucket_name=None,
+                                     s3_bucket_prefix=None,
+                                     emit_interval=None,
+                                     enabled=False)
+
+    att_conn_draining = ELBAttConnectionDraining(enabled=True, timeout=300)
+
+    att_conn_settings = ELBAttConnectionSettings(idle_timeout=60)
+    atts = ELBAtts(cross_zone_load_balancing=att_czlb,
+                   access_log=att_access_log,
+                   connection_draining=att_conn_draining,
+                   connection_settings=att_conn_settings)
+    cfg = ELBConfig(name='snippets-stats',
+                    listeners=listeners,
+                    security_groups=['sg-02552a69'],
+                    subnets=['subnet-10685f78'],
+                    tags=[],
+                    health_check=hc,
+                    elb_atts=atts)
+    return cfg
+
+
+def define_nucleus_prod():
+    nodeport = elb_tool.ctx.get_service_nodeport(
+        'nucleus-prod', 'nucleus-nodeport', 'https')
+    # Health check config
+
+    hc = ELBHealthCheckConfig(target_path='/',
+                              target_port=nodeport,
+                              target_proto='HTTP',
+                              healthy_threshold=2,
+                              unhealthy_threshold=6,
+                              timeout=5,
+                              interval=10)
+    # Listener config
+    listeners = {}
+
+    listeners[80] = \
+        ELBListenerConfig(protocol='TCP',
+                          load_balancer_port=80,
+                          instance_protocol='TCP',
+                          instance_port=redirector_port,
+                          ssl_arn=None)
+    listeners[443] = ELBListenerConfig(
+        protocol='SSL',
+        load_balancer_port=443,
+        instance_protocol='TCP',
+        instance_port=nodeport,
+        ssl_arn='arn:aws:acm:eu-central-1:236517346949:certificate/9a38de62-3461-43a4-9027-4ec5d165e0d6')
+    # Attributes
+
+    att_czlb = ELBAttCrossZoneLoadBalancing(enabled=True)
+
+    att_access_log = ELBAttAccessLog(s3_bucket_name=None,
+                                     s3_bucket_prefix=None,
+                                     emit_interval=None,
+                                     enabled=False)
+
+    att_conn_draining = ELBAttConnectionDraining(enabled=True, timeout=300)
+
+    att_conn_settings = ELBAttConnectionSettings(idle_timeout=60)
+    atts = ELBAtts(cross_zone_load_balancing=att_czlb,
+                   access_log=att_access_log,
+                   connection_draining=att_conn_draining,
+                   connection_settings=att_conn_settings)
+    cfg = ELBConfig(name='nucleus-prod',
+                    listeners=listeners,
+                    security_groups=['sg-02552a69'],
+                    subnets=['subnet-10685f78'],
+                    tags=[],
+                    health_check=hc,
+                    elb_atts=atts)
+    return cfg
+
+
+def define_mdn_dev():
+    # Health check config
+
+    hc = ELBHealthCheckConfig(target_path=None,
+                              target_port=31616,
+                              target_proto='TCP',
+                              healthy_threshold=2,
+                              unhealthy_threshold=6,
+                              timeout=5,
+                              interval=10)
+    # Listener config
+    listeners = {}
+
+    listeners[443] = ELBListenerConfig(
+        protocol='HTTPS',
+        load_balancer_port=443,
+        instance_protocol='HTTP',
+        instance_port=31616,
+        ssl_arn='arn:aws:acm:eu-central-1:236517346949:certificate/8e3c817f-dec5-4ab7-9bdf-38f731c8ee4e')
+    # Attributes
+
+    att_czlb = ELBAttCrossZoneLoadBalancing(enabled=False)
+
+    att_access_log = ELBAttAccessLog(s3_bucket_name=None,
+                                     s3_bucket_prefix=None,
+                                     emit_interval=None,
+                                     enabled=False)
+
+    att_conn_draining = ELBAttConnectionDraining(enabled=False, timeout=300)
+
+    att_conn_settings = ELBAttConnectionSettings(idle_timeout=60)
+    atts = ELBAtts(cross_zone_load_balancing=att_czlb,
+                   access_log=att_access_log,
+                   connection_draining=att_conn_draining,
+                   connection_settings=att_conn_settings)
+    cfg = ELBConfig(name='a37e4a92db2a611e78dc902859405480',
+                    listeners=listeners,
+                    security_groups=['sg-46b6642c'],
+                    subnets=['subnet-10685f78'],
+                    tags=[{'Key': 'kubernetes.io/service-name',
+                           'Value': 'mdn-prod/web'},
+                          {'Key': 'KubernetesCluster',
+                           'Value': 'frankfurt.moz.works'},
+                          {'Key': 'kubernetes.io/cluster/frankfurt.moz.works',
+                           'Value': 'owned'}],
+                    health_check=hc,
+                    elb_atts=atts)
+    return cfg
+
+
+def define_openvpn():
+    nodeport = elb_tool.ctx.get_service_nodeport(
+        'openvpn', 'yummy-armadillo-openvpn', 'openvpn')
+    # Health check config
+
+    hc = ELBHealthCheckConfig(target_path=None,
+                              target_port=nodeport,
+                              target_proto='TCP',
+                              healthy_threshold=2,
+                              unhealthy_threshold=6,
+                              timeout=5,
+                              interval=10)
+    # Listener config
+    listeners = {}
+
+    listeners[443] = \
+        ELBListenerConfig(protocol='TCP',
+                          load_balancer_port=443,
+                          instance_protocol='TCP',
+                          instance_port=nodeport,
+                          ssl_arn=None)
+    # Attributes
+
+    att_czlb = ELBAttCrossZoneLoadBalancing(enabled=False)
+
+    att_access_log = ELBAttAccessLog(s3_bucket_name=None,
+                                     s3_bucket_prefix=None,
+                                     emit_interval=None,
+                                     enabled=False)
+
+    att_conn_draining = ELBAttConnectionDraining(enabled=False, timeout=300)
+
+    att_conn_settings = ELBAttConnectionSettings(idle_timeout=60)
+    atts = ELBAtts(cross_zone_load_balancing=att_czlb,
+                   access_log=att_access_log,
+                   connection_draining=att_conn_draining,
+                   connection_settings=att_conn_settings)
+    cfg = ELBConfig(name='aebf2210abda911e78dc902859405480',
+                    listeners=listeners,
+                    security_groups=['sg-82c16be8'],
+                    subnets=['subnet-10685f78'],
+                    tags=[{'Key': 'kubernetes.io/service-name',
+                           'Value': 'openvpn/yummy-armadillo-openvpn'},
+                          {'Key': 'KubernetesCluster',
+                           'Value': 'frankfurt.moz.works'},
+                          {'Key': 'kubernetes.io/cluster/frankfurt.moz.works',
+                           'Value': 'owned'}],
+                    health_check=hc,
+                    elb_atts=atts)
+    return cfg
+
+
+elb_tool.define_generic_elb(define_deis_router())
+elb_tool.define_generic_elb(define_basket_prod())
+elb_tool.define_generic_elb(define_basket_stage())
+elb_tool.define_generic_elb(define_snippets())
+elb_tool.define_generic_elb(define_careers())
+elb_tool.define_generic_elb(define_bedrock_prod())
+elb_tool.define_generic_elb(define_bedrock_stage())
+elb_tool.define_generic_elb(define_snippets_stats())
+elb_tool.define_generic_elb(define_nucleus_prod())
+elb_tool.define_generic_elb(define_mdn_dev())
+elb_tool.define_generic_elb(define_openvpn())
+
+
+# TODO: to automatically assign instance ports to K8s nodeports, replace
+# target_port=30150,
+#   with
+# target_port = elb_tool.ctx.get_service_nodeport(service_namespace, service_name),
+#    OR
+# target_port = elb_tool.ctx.get_service_nodeport(service_namespace, service_name, "my_nodeport_name"),
+
+# TODO: to use the redirector service nodeport:
+# target_port = redirector_port
+
+elb_tool.test_elbs()

--- a/elb_automation/meaoelb/templates.py
+++ b/elb_automation/meaoelb/templates.py
@@ -1,0 +1,102 @@
+"""
+Code generation templates
+"""
+
+ELB_LISTENER_CONFIG_TEMPLATE = """
+    listeners[{load_balancer_port}] = \\
+        ELBListenerConfig(protocol = {protocol},
+                        load_balancer_port = {load_balancer_port},
+                        instance_protocol = {instance_protocol},
+                        instance_port = {instance_port},
+                        ssl_arn = {ssl_arn})"""
+
+ELB_HEALTHCHECK_CONFIG_TEMPLATE = """
+    hc = ELBHealthCheckConfig(target_path={target_path},
+                              target_port={target_port},
+                              target_proto={target_proto},
+                              healthy_threshold={healthy_threshold},
+                              unhealthy_threshold={unhealthy_threshold},
+                              timeout={timeout},
+                              interval={interval})"""
+
+
+ELB_ATT_CROSS_ZONE_LOAD_BALANCING_TEMPLATE = """
+    att_czlb = ELBAttCrossZoneLoadBalancing(enabled={enabled})"""
+
+ELB_ATT_ACCESS_LOG_TEMPLATE = """
+    att_access_log = ELBAttAccessLog(s3_bucket_name={s3_bucket_name},
+                                     s3_bucket_prefix={s3_bucket_prefix},
+                                     emit_interval={emit_interval},
+                                     enabled={enabled})"""
+
+ELB_ATT_CONNECTION_DRAINING = """
+    att_conn_draining = ELBAttConnectionDraining(enabled={enabled}, timeout={timeout})"""
+
+ELB_ATT_CONNECTION_SETTINGS = """
+    att_conn_settings = ELBAttConnectionSettings(idle_timeout={idle_timeout})"""
+
+ELB_ATTS_TEMPLATE = """
+{cross_zone_load_balancing}
+{access_log}
+{connection_draining}
+{connection_settings}
+    atts = ELBAtts(cross_zone_load_balancing=att_czlb,
+                   access_log=att_access_log,
+                   connection_draining=att_conn_draining,
+                   connection_settings=att_conn_settings)"""
+
+
+ELB_CONFIG_TEMPLATE = """
+def {method_name}():
+    # Health check config
+    {health_check}
+    # Listener config
+    listeners = {{}}
+    {listeners}
+    # Attributes
+    {attributes}
+    cfg = ELBConfig(name = {name},
+                    listeners = listeners,
+                    security_groups = {security_groups},
+                    subnets = {subnets},
+                    tags = {tags},
+                    health_check = hc,
+                    elb_atts = atts)
+    return cfg
+"""
+
+HEADER_TEMPLATE = """
+from meaoelb.elb_tool import ELBTool
+from meaoelb.config import *
+from meaoelb.elb_ctx import ELBContext
+
+AWS_REGION = ''
+TARGET_CLUSTER = ''
+ASG = "nodes.{}".format(TARGET_CLUSTER)
+VPC = ''
+SUBNET_IDS = ['']
+
+elb_tool = ELBTool(
+    aws_region=AWS_REGION,
+    target_cluster=TARGET_CLUSTER,
+    asg_name=ASG,
+    vpc_id=VPC,
+    subnet_ids=SUBNET_IDS)
+
+redirector_port = elb_tool.ctx.get_redirector_service_nodeport()
+"""
+
+FOOTER_TEMPLATE = """
+
+# TODO: to automatically assign instance ports to K8s nodeports, replace
+# target_port=30150,
+#   with
+# target_port = elb_tool.ctx.get_service_nodeport(service_namespace, service_name),
+#    OR
+# target_port = elb_tool.ctx.get_service_nodeport(service_namespace, service_name, "my_nodeport_name"),
+
+# TODO: to use the redirector service nodeport:
+# target_port = redirector_port
+
+elb_tool.test_elbs()
+"""


### PR DESCRIPTION
Here's some weekend work that reads an AWS region and generates Python code for ELBs. Included are Tokyo and Frankfurt regions. This allows us to get away from Terraform-managed ELBs (yay). I can do the same for us-west-2. 

```
# load Tokyo K8s config first
$ make ap-northeast-1
python3 -m meaoelb.ap_northeast_1
Dry run mode is enabled
	➤ ELB config is valid: a63990d51037511e7845b06353bb5962
	➤ ELB config is valid: snippets
	➤ ELB config is valid: careers
	➤ ELB config is valid: snippets-stats
	➤ ELB config is valid: a09c0082826ea11e7845b06353bb5962
	➤ ELB config is valid: bedrock-stage
	➤ ELB config is valid: bedrock-prod
	➤ ELB config is valid: basket-stage
	➤ ELB config is valid: basket-prod
# load Frankfurt K8s config first
$ make eu-central-1
python3 -m meaoelb.eu_central_1
Dry run mode is enabled
	➤ ELB config is valid: a82511f724fb611e78dc902859405480
	➤ ELB config is valid: basket-prod
	➤ ELB config is valid: basket-stage
	➤ ELB config is valid: snippets
	➤ ELB config is valid: careers
	➤ ELB config is valid: bedrock-prod
	➤ ELB config is valid: bedrock-stage
	➤ ELB config is valid: snippets-stats
	➤ ELB config is valid: nucleus-prod
	➤ ELB config is valid: a37e4a92db2a611e78dc902859405480
	➤ ELB config is valid: aebf2210abda911e78dc902859405480
```
