### PR TITLE
fix the MDN Frankfurt prod.mm.sh KUBECONFIG path for Jenkins

### DIFF
--- a/apps/mdn/mdn-aws/k8s/regions/frankfurt/prod.mm.sh
+++ b/apps/mdn/mdn-aws/k8s/regions/frankfurt/prod.mm.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 echo '--> Setting environment to PROD in FRANKFURT'
 
-export KUBECONFIG=~/.kube/frankfurt.config
+export KUBECONFIG=${HOME}/.kube/frankfurt.config
 
 # Define defaults for environment variables that personalize the commands.
 export TARGET_ENVIRONMENT=prod


### PR DESCRIPTION
This fix enables `kubectl` to be used within Jenkins for deploying to the Frankfurt K8s cluster.

Thanks to @metadave and @jwhitlock for all of their help with this!