### PR TITLE
bug 1431259: add asset cdn cname to primary cdn cnames

### DIFF
--- a/apps/mdn/mdn-aws/infra/mdn-cdn/mdn_cdn.tf
+++ b/apps/mdn/mdn-aws/infra/mdn-cdn/mdn_cdn.tf
@@ -26,7 +26,7 @@ module "mdn-primary-cloudfront-stage" {
 module "mdn-primary-cloudfront-prod" {
    source = "./cloudfront_primary"
    acm_cert_arn = "arn:aws:acm:us-east-1:236517346949:certificate/144c40ad-1a60-4865-a252-58ff23961787"
-   aliases = ["developer.mozilla.org"]
+   aliases = ["developer.mozilla.org", "cdn.mdn.mozilla.net"]
    comment = "Primary Prod CDN for AWS-hosted MDN"
    distribution_name = "MDNPrimaryProdCDN"
    domain_name = "prod.mdn.moz.works"
@@ -57,4 +57,3 @@ module "mdn-cloudfront-attachments-prod" {
     distribution_name = "MDNProdAttachmentsCDN"
     domain_name = "mdn-demos-origin.moz.works"
 }
-


### PR DESCRIPTION
This PR adds the domain name for the asset CDN to the primary CDN's list of CNAME's. This is to accommodate traffic from stale asset URL's after switching the asset traffic away from the asset CDN to the new primary CDN. This is to support @jwhitlock's strategy for turning off the production asset CDN (see https://github.com/mozmeao/infra/issues/775#issuecomment-381168302).