### PR TITLE
bug 1429933, MDN: Set celery log level via arg

### DIFF
--- a/apps/mdn/mdn-aws/k8s/celery.workers.deploy.yaml.j2
+++ b/apps/mdn/mdn-aws/k8s/celery.workers.deploy.yaml.j2
@@ -8,6 +8,7 @@
             - worker
             - "--events"
             - "--autoreload"
+            - "--loglevel=INFO"
             - "--logfile=/dev/stdout"
             - "--concurrency={{ CELERY_WORKERS_CONCURRENCY }}"
             - "--queues={{ CELERY_WORKERS_QUEUES }}"


### PR DESCRIPTION
The ``CELERYD_LOGLEVEL`` setting is [deprecated in Celery 2.4](http://docs.celeryproject.org/en/latest/history/changelog-2.4.html#version-2-4-0) and slated for removal in 4.0. Set it with the command line argument ``--loglevel`` instead.

This change is needed before https://github.com/mozilla/kuma/pull/4748 is merged and deployed.