### PR TITLE
bug 1431259: add dwf_sg_task_completion cookie to default

### DIFF
--- a/apps/mdn/mdn-aws/infra/mdn-cdn/cloudfront_primary/cloudfront.tf
+++ b/apps/mdn/mdn-aws/infra/mdn-cdn/cloudfront_primary/cloudfront.tf
@@ -588,7 +588,7 @@ resource "aws_cloudfront_distribution" "mdn-primary-cf-dist" {
 
       cookies {
         forward = "whitelist"
-        whitelisted_names = ["django_language", "sessionid"]
+        whitelisted_names = ["django_language", "dwf_sg_task_completion", "sessionid"]
       }
     }
   }


### PR DESCRIPTION
The "zoned" documents (e.g., https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/alarms) fall into the default primary CDN behavior, but I forgot to ensure that the `dwf_sg_task_completion` cookie was added to its white-list, as it is for the normal document behavior. This PR does that. The change has already been applied to the primary CDN's on stage (developer.allizom.org) and production (developer.mozilla.org), and tested on both.

NOTE: Ideally, it would be better to make this change first to the terraform, then apply and test, as the terraform should be treated as the master, but terraform doesn't yet provide the ability to specify behavior precedence, so that approach entails a period of disorder (and serious errors) until the order can be corrected manually.