### PR TITLE
cleanup redirector service code

### DIFF
--- a/k8s/install/services/http_to_https_redirector/Dockerfile
+++ b/k8s/install/services/http_to_https_redirector/Dockerfile
@@ -1,2 +1,0 @@
-FROM nginx
-COPY nginx.conf /etc/nginx/nginx.conf

--- a/k8s/install/services/http_to_https_redirector/Makefile
+++ b/k8s/install/services/http_to_https_redirector/Makefile
@@ -1,7 +1,3 @@
-image:
-	docker build -t quay.io/mozmar/redirector .
-	docker push quay.io/mozmar/redirector
-
 deploy:
 	kubectl create namespace redirector
 	kubectl -n redirector create configmap redirector-config --from-file=redirector-config=redirector.conf

--- a/k8s/install/services/http_to_https_redirector/README.md
+++ b/k8s/install/services/http_to_https_redirector/README.md
@@ -1,11 +1,5 @@
 # MozMEAO http->https redirector
 
-### Building the image
-
-```shell
-make image
-```
-
 ### Deploying the service
 
 ```shell


### PR DESCRIPTION
the redirector uses `nginx:latest` instead of our custom image.