### PR TITLE
Ignore slack errors in the example script

### DIFF
--- a/docs/slack-notify.sh
+++ b/docs/slack-notify.sh
@@ -68,4 +68,4 @@ else
     exit 1
 fi
 
-slack-cli -d "${CHANNEL}" "${MESSAGE}"
+slack-cli -d "${CHANNEL}" "${MESSAGE}" || true


### PR DESCRIPTION
Not doing this will fail a build due to notification failure, which should just be ignored.