### PR TITLE
[Fix #997] Careers Static Terraform

### DIFF
--- a/apps/careers/tf/careers.tf
+++ b/apps/careers/tf/careers.tf
@@ -10,59 +10,6 @@ terraform {
   }
 }
 
-resource "aws_iam_user" "careers" {
-  name = "careers-upload"
-}
-
-resource "aws_iam_user_policy" "careers-upload" {
-  name = "careers-upload"
-  user = "${aws_iam_user.careers.name}"
-
-  policy = <<EOF
-{
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Effect": "Allow",
-            "Action": [
-                "s3:ListBucket"
-            ],
-            "Resource": [
-                "arn:aws:s3:::mozilla-careers"
-            ]
-        },
-        {
-            "Effect": "Allow",
-            "Action": [
-                "s3:*"
-            ],
-            "Resource": [
-                "arn:aws:s3:::mozilla-careers/*"
-            ]
-        },
-        {
-            "Effect": "Allow",
-            "Action": [
-                "s3:ListBucket"
-            ],
-            "Resource": [
-                "arn:aws:s3:::mozilla-careers-stage"
-            ]
-        },
-        {
-            "Effect": "Allow",
-            "Action": [
-                "s3:*"
-            ],
-            "Resource": [
-                "arn:aws:s3:::mozilla-careers-stage/*"
-            ]
-        }
-    ]
-}
-EOF
-}
-
 resource "aws_s3_bucket" "logs" {
   bucket = "mozilla-careers-logs"
   acl    = "log-delivery-write"

--- a/apps/careers/tf/careers.tf
+++ b/apps/careers/tf/careers.tf
@@ -1,0 +1,283 @@
+provider "aws" {
+  region = "${var.region}"
+}
+
+terraform {
+  backend "s3" {
+    bucket = "mozilla-careers-s3-provisioning-tf-state"
+    key    = "tf-state"
+    region = "us-west-2"
+  }
+}
+
+resource "aws_iam_user" "careers" {
+  name = "careers-upload"
+}
+
+resource "aws_iam_user_policy" "careers-upload" {
+  name = "careers-upload"
+  user = "${aws_iam_user.careers.name}"
+
+  policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "s3:ListBucket"
+            ],
+            "Resource": [
+                "arn:aws:s3:::mozilla-careers"
+            ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "s3:*"
+            ],
+            "Resource": [
+                "arn:aws:s3:::mozilla-careers/*"
+            ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "s3:ListBucket"
+            ],
+            "Resource": [
+                "arn:aws:s3:::mozilla-careers-stage"
+            ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "s3:*"
+            ],
+            "Resource": [
+                "arn:aws:s3:::mozilla-careers-stage/*"
+            ]
+        }
+    ]
+}
+EOF
+}
+
+resource "aws_s3_bucket" "logs" {
+  bucket = "mozilla-careers-logs"
+  acl    = "log-delivery-write"
+}
+
+resource "aws_s3_bucket" "mozilla-careers" {
+  bucket = "mozilla-careers"
+  region = "${var.region}"
+  acl    = "log-delivery-write"
+
+  force_destroy = ""
+
+  hosted_zone_id = "${lookup(var.hosted-zone-id-defs, var.region)}"
+
+  logging {
+    target_bucket = "${aws_s3_bucket.logs.bucket}"
+    target_prefix = "logs/"
+  }
+
+  website {
+    index_document = "index.html"
+  }
+
+  website_domain   = "s3-website-${var.region}.amazonaws.com"
+  website_endpoint = "mozilla-careers.s3-website-${var.region}.amazonaws.com"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Id": "careers policy",
+  "Statement": [
+    {
+      "Sid": "careersAllowListBucket",
+      "Effect": "Allow",
+      "Principal": "*",
+      "Action": "s3:ListBucket",
+      "Resource": "arn:aws:s3:::mozilla-careers"
+    },
+    {
+      "Sid": "careersAllowIndexDotHTML",
+      "Effect": "Allow",
+      "Principal": "*",
+      "Action": "s3:GetObject",
+      "Resource": "arn:aws:s3:::mozilla-careers/*"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_s3_bucket" "mozilla-careers-stage" {
+  bucket = "mozilla-careers-stage"
+  region = "${var.region}"
+  acl    = "log-delivery-write"
+
+  force_destroy = ""
+
+  hosted_zone_id = "${lookup(var.hosted-zone-id-defs, var.region)}"
+
+  logging {
+    target_bucket = "${aws_s3_bucket.logs.bucket}"
+    target_prefix = "stage-logs/"
+  }
+
+  website {
+    index_document = "index.html"
+  }
+
+  website_domain   = "s3-website-${var.region}.amazonaws.com"
+  website_endpoint = "mozilla-careers-stage.s3-website-${var.region}.amazonaws.com"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Id": "careers stage policy",
+  "Statement": [
+    {
+      "Sid": "careersStageAllowListBucket",
+      "Effect": "Allow",
+      "Principal": "*",
+      "Action": "s3:ListBucket",
+      "Resource": "arn:aws:s3:::mozilla-careers-stage"
+    },
+    {
+      "Sid": "careersStageAllowIndexDotHTML",
+      "Effect": "Allow",
+      "Principal": "*",
+      "Action": "s3:GetObject",
+      "Resource": "arn:aws:s3:::mozilla-careers-stage/*"
+    }
+  ]
+}
+EOF
+}
+
+
+resource "aws_cloudfront_distribution" "s3_distribution" {
+  origin {
+    domain_name = "mozilla-careers.s3-website-us-west-2.amazonaws.com"
+    origin_id   = "mozilla-careers"
+    custom_origin_config {
+      origin_protocol_policy = "http-only"
+      http_port = "80"
+      https_port = "443"
+      origin_ssl_protocols = ["TLSv1"]
+    }
+  }
+
+  enabled             = true
+  is_ipv6_enabled     = true
+  comment             = "No comment"
+  default_root_object = "index.html"
+
+  logging_config {
+    include_cookies = false
+    bucket          = "mozilla-careers-logs.s3.amazonaws.com"
+    prefix          = "cflogs"
+  }
+
+  aliases = ["careers.mozilla.org"]
+
+  default_cache_behavior {
+    allowed_methods  = ["GET", "HEAD", "OPTIONS"]
+    cached_methods   = ["GET", "HEAD"]
+    target_origin_id = "mozilla-careers"
+
+    forwarded_values {
+      query_string = false
+
+      cookies {
+        forward = "none"
+      }
+    }
+
+    viewer_protocol_policy = "redirect-to-https"
+    min_ttl                = 0
+    default_ttl            = 60
+    max_ttl                = 86400
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  viewer_certificate {
+    # TODO
+    # acm_certificate_arn = "arn:aws:acm:us-west-2:236517346949:certificate/ae2d2e64-b345-4bc1-a49a-5860c73a0809"
+    cloudfront_default_certificate = true
+    ssl_support_method  = "sni-only"
+
+    # https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution.html#minimum_protocol_version
+    minimum_protocol_version = "TLSv1"
+  }
+}
+
+
+resource "aws_cloudfront_distribution" "stage_s3_distribution" {
+  origin {
+    domain_name = "mozilla-careers-stage.s3-website-us-west-2.amazonaws.com"
+    origin_id   = "mozilla-careersstage"
+    custom_origin_config {
+      origin_protocol_policy = "http-only"
+      http_port = "80"
+      https_port = "443"
+      origin_ssl_protocols = ["TLSv1"]
+    }
+  }
+
+  enabled             = true
+  is_ipv6_enabled     = true
+  comment             = "No comment"
+  default_root_object = "index.html"
+
+  logging_config {
+    include_cookies = false
+    bucket          = "mozilla-careers-logs.s3.amazonaws.com"
+    prefix          = "cflogs-stage"
+  }
+
+  aliases = ["careers.allizom.org"]
+
+  default_cache_behavior {
+    allowed_methods  = ["GET", "HEAD", "OPTIONS"]
+    cached_methods   = ["GET", "HEAD"]
+    target_origin_id = "mozilla-careersstage"
+
+    forwarded_values {
+      query_string = false
+
+      cookies {
+        forward = "none"
+      }
+    }
+
+    viewer_protocol_policy = "redirect-to-https"
+    min_ttl                = 0
+    default_ttl            = 60
+    max_ttl                = 86400
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  viewer_certificate {
+    # TODO
+    # acm_certificate_arn = "arn:aws:acm:us-west-2:236517346949:certificate/e3d6aa9a-0a9b-4fed-b2fa-d05ae0156677"
+    cloudfront_default_certificate = true
+    ssl_support_method  = "sni-only"
+
+    # https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution.html#minimum_protocol_version
+    minimum_protocol_version = "TLSv1"
+  }
+}

--- a/apps/careers/tf/careers.tf
+++ b/apps/careers/tf/careers.tf
@@ -157,9 +157,7 @@ resource "aws_cloudfront_distribution" "s3_distribution" {
   }
 
   viewer_certificate {
-    # TODO
-    # acm_certificate_arn = "arn:aws:acm:us-west-2:236517346949:certificate/ae2d2e64-b345-4bc1-a49a-5860c73a0809"
-    cloudfront_default_certificate = true
+    acm_certificate_arn = "arn:aws:acm:us-east-1:236517346949:certificate/6190c26d-0d99-4e45-b460-9bb44bf34f6e"
     ssl_support_method  = "sni-only"
 
     # https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution.html#minimum_protocol_version
@@ -219,9 +217,7 @@ resource "aws_cloudfront_distribution" "stage_s3_distribution" {
   }
 
   viewer_certificate {
-    # TODO
-    # acm_certificate_arn = "arn:aws:acm:us-west-2:236517346949:certificate/e3d6aa9a-0a9b-4fed-b2fa-d05ae0156677"
-    cloudfront_default_certificate = true
+    acm_certificate_arn = "arn:aws:acm:us-east-1:236517346949:certificate/88572219-24de-43e2-99ba-bcbb8820c319"
     ssl_support_method  = "sni-only"
 
     # https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution.html#minimum_protocol_version

--- a/apps/careers/tf/provision.sh
+++ b/apps/careers/tf/provision.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+set -e
+set -u
+
+CAREERS_PROVISIONING_REGION="us-west-2"
+TERRAFORM_ENV="careers"
+CAREERS_PROVISIONING_BUCKET="mozilla-careers-s3-provisioning-tf-state"
+STATE_BUCKET_REGION="us-west-2"
+
+setup_tf_s3_state_store() {
+    echo "Creating Terraform state bucket at s3://${CAREERS_PROVISIONING_BUCKET} (region ${STATE_BUCKET_REGION})"
+    # The following environment variables are defined in config.sh
+    aws s3 mb s3://${CAREERS_PROVISIONING_BUCKET} --region ${STATE_BUCKET_REGION}
+}
+
+setup_tf_envs() {
+    # this MUST be run in the dir that this file resides in
+    set +e
+    terraform env new careers
+    set -e
+}
+
+check_state_store() {
+    echo "Checking state store"
+    set +e
+    if aws s3 ls s3://${CAREERS_PROVISIONING_BUCKET} > /dev/null 2>&1; then
+        echo "State store already exists"
+    else
+        echo "Setting up state store"
+        setup_tf_s3_state_store
+        echo "Setting up envs"
+        setup_tf_envs
+    fi
+    set -e
+}
+
+tf_main() {
+    # it's safe to always init the s3 backend
+    terraform init
+
+    setup_tf_envs
+
+    # switch env to virginia, tokyo etc
+    terraform env select ${TERRAFORM_ENV}
+
+    # import local modules
+    terraform get
+
+    PLAN=$(mktemp)
+    terraform plan --out $PLAN
+
+
+    echo "Please verify plan output above and enter the command"
+    echo "'make it so' followed by enter to continue."
+    echo "Otherwise, Ctrl-C to abort"
+    read
+
+    # if terraform plan fails, the next command won't run due to
+    # set -e at the top of the script.
+    terraform apply $PLAN
+    rm $PLAN
+}
+
+check_state_store
+tf_main

--- a/apps/careers/tf/variables.tf
+++ b/apps/careers/tf/variables.tf
@@ -1,0 +1,13 @@
+variable "region" {
+  default = "us-west-2"
+}
+
+variable "hosted-zone-id-defs" {
+  # See: https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_website_region_endpoints
+  type = "map"
+
+  default = {
+    us-east-1 = "Z3AQBSTGFYJSTF"
+    us-west-2 = "Z3BJ6K6RIION7M"
+  }
+}


### PR DESCRIPTION
Creates
 - prod bucket
 - staging bucket
 - logs bucket
 - IAM user with S3 permissions to the buckets above
 - CF distribution for staging
 - CF distribution for prod

I need help getting certificates for the CF distributions. We have certificates for careers but they are both on us-west-2.

The above has been applied. You can test the staging CF dist at https://dmin398ukjj8z.cloudfront.net/