### PR TITLE
Expire metadata after 7 days.

### DIFF
--- a/apps/snippets/infra/multi_region/tf/storage/storage.tf
+++ b/apps/snippets/infra/multi_region/tf/storage/storage.tf
@@ -44,6 +44,16 @@ EOF
     }
   }
 
+  lifecycle_rule {
+    id      = "metadata"
+    prefix  = "metadata/"
+    enabled = true
+
+    expiration {
+      days = 7
+    }
+  }
+
   versioning {
     enabled = true
   }


### PR DESCRIPTION
An automated job will fetch metadata from our buckets daily and after that they
are no longer of use.


@metadave I haven't applied this one yet b/c the dir still contains references to tokyo and I wanted to check with you first.

Thanks!