### PR TITLE
fix careers prod lambda filename

### DIFF
--- a/apps/careers/tf/careers.tf
+++ b/apps/careers/tf/careers.tf
@@ -156,7 +156,7 @@ resource "aws_cloudfront_distribution" "s3_distribution" {
 
     viewer_protocol_policy = "redirect-to-https"
     min_ttl                = 0
-    default_ttl            = 60
+    default_ttl            = 900
     max_ttl                = 86400
   }
 
@@ -227,7 +227,7 @@ resource "aws_cloudfront_distribution" "stage_s3_distribution" {
 
     viewer_protocol_policy = "redirect-to-https"
     min_ttl                = 0
-    default_ttl            = 60
+    default_ttl            = 900
     max_ttl                = 86400
   }
 
@@ -277,7 +277,7 @@ EOF
 data "archive_file" "prod-lambda-zip" {
   type        = "zip"
   source_file = "${path.module}/lambda-headers.js"
-  output_path = "${path.module}/lambda-headers.zip"
+  output_path = "${path.module}/prod-lambda-headers.zip"
 }
 
 


### PR DESCRIPTION
prod lambda@edge was not applied due to invalid filename. My guess is that this ran because the old filename was still on disk. 

ttl was manually set to 900 during performance troubleshooting, the ttl change in this PR brings the TF into sync with what's in prod.